### PR TITLE
wip: update color

### DIFF
--- a/GZCTF/ClientApp/src/components/TeamCard.tsx
+++ b/GZCTF/ClientApp/src/components/TeamCard.tsx
@@ -118,11 +118,11 @@ const TeamCard: FC<TeamCardProps> = (props) => {
                           backgroundColor:
                             theme.colorScheme === 'dark'
                               ? theme.colors[theme.primaryColor][8] + '40'
-                              : theme.colors[theme.primaryColor][2],
+                              : theme.colors[theme.primaryColor][6],
                           color:
                             theme.colorScheme === 'dark'
                               ? theme.colors[theme.primaryColor][4]
-                              : theme.colors.gray[8],
+                              : theme.colors.white[0],
                         },
                       })}
                       position="left"
@@ -139,9 +139,9 @@ const TeamCard: FC<TeamCardProps> = (props) => {
                             color:
                               theme.colorScheme === 'dark'
                                 ? theme.colors[theme.primaryColor][2]
-                                : theme.colors[theme.primaryColor][7],
+                                : theme.colors[theme.primaryColor][6],
                             backgroundColor:
-                              theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
+                              theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.colors.gray[1],
                           },
                         })}
                       >


### PR DESCRIPTION
I' m coming to update the color again. And I think the tooltip of the activation button in teamcard looks unnatural. I browsed the document of mantine again and again but found nothing suitable.
What's more, as the picture shows, the tooltip of the avatar shows an **unexpected offset** due to the restrictions of the parent element. But I still can't solve the problem because I'm really very good(Oh the stupid translation).
![GZCTFtooptip偏移](https://user-images.githubusercontent.com/93419086/184889141-b16c16fc-b6fb-4811-b5d1-5cfbf37d4f84.png)
