### PR TITLE
fix(frontend): sort announcements by time

### DIFF
--- a/src/GZCTF/ClientApp/src/components/GameNoticePanel.tsx
+++ b/src/GZCTF/ClientApp/src/components/GameNoticePanel.tsx
@@ -120,11 +120,9 @@ const GameNoticePanel: FC = () => {
   const filteredNotices = ApplyFilter(allNotices, filter)
 
   filteredNotices.sort((a, b) =>
-    a.type === NoticeType.Normal && b.type === NoticeType.Normal
-      ? 0
-      : a.type === NoticeType.Normal
-      ? -1
-      : 1
+    a.type !== b.type && (a.type === NoticeType.Normal || b.type == NoticeType.Normal)
+      ? (a.type === NoticeType.Normal ? -1 : 1)
+      : (dayjs(a.time).isAfter(b.time) ? -1 : 1)
   )
 
   return (


### PR DESCRIPTION
因为后端将“通知”排序排在前面的时候，并没有将通知按照其发布时间排序。所以前端除了要把“通知”排序在前面之外，还要根据通知的发布时间再排个序。