### PR TITLE
fix: use `System.Uri` to parse host from k8s config

### DIFF
--- a/src/GZCTF/Services/Container/Provider/KubernetesProvider.cs
+++ b/src/GZCTF/Services/Container/Provider/KubernetesProvider.cs
@@ -55,7 +55,7 @@ public class KubernetesProvider : IContainerProvider<Kubernetes, KubernetesMetad
 
         var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(_kubernetesMetadata.Config.KubeConfig);
 
-        _kubernetesMetadata.HostIp = config.Host[(config.Host.LastIndexOf('/') + 1)..config.Host.LastIndexOf(':')];
+        _kubernetesMetadata.HostIp = new System.Uri(config.Host).Host;
 
         _kubernetesClient = new Kubernetes(config);
 


### PR DESCRIPTION
Error will be thrown when there is no ":" in `config.Host`(e.g. `https://api.foo.bar`), fixed by replacing manual substring extraction with the `System.Uri` object's `Host` property to retrieve the host IP.