### PR TITLE
fix: remove user participation when leaving team

### DIFF
--- a/src/GZCTF/Controllers/TeamController.cs
+++ b/src/GZCTF/Controllers/TeamController.cs
@@ -450,7 +450,6 @@ public partial class TeamController(
             await participationRepository.RemoveUserParticipations(user!, team, token);
 
             await teamRepository.SaveAsync(token);
-            await participationRepository.SaveAsync(token);
             await trans.CommitAsync(token);
 
             logger.Log(Program.StaticLocalizer[nameof(Resources.Program.Team_UserLeft), team.Name], user,

--- a/src/GZCTF/Controllers/TeamController.cs
+++ b/src/GZCTF/Controllers/TeamController.cs
@@ -447,8 +447,10 @@ public partial class TeamController(
                 return BadRequest(new RequestResponse(localizer[nameof(Resources.Program.Team_Locked)]));
 
             team.Members.Remove(user!);
+            await participationRepository.RemoveUserParticipations(user!, team, token);
 
             await teamRepository.SaveAsync(token);
+            await participationRepository.SaveAsync(token);
             await trans.CommitAsync(token);
 
             logger.Log(Program.StaticLocalizer[nameof(Resources.Program.Team_UserLeft), team.Name], user,


### PR DESCRIPTION
## Motivation

User's participation won't be automatically removed after he leave the team