### PR TITLE
fix(monitor/submission): wrong dependence for useEffect

### DIFF
--- a/src/GZCTF/ClientApp/src/pages/games/[id]/monitor/Submissions.tsx
+++ b/src/GZCTF/ClientApp/src/pages/games/[id]/monitor/Submissions.tsx
@@ -157,7 +157,7 @@ const Submissions: FC = () => {
         })
       }
     }
-  })
+  }, [game, numId, t])
 
   const filteredSubs = newSubmissions.current.filter(
     (item) => type === 'All' || item.status === type


### PR DESCRIPTION
**Motivation**

The Notification will pop-up when recieved a new event

**Root Cause**

Wrong monitor for React variable trigger the `useEffect` method, then re-run the connect methods.

**Fix**

Pass monitoring variables to React.

Co-Authored-By: @GZTimeWalker 