### PR TITLE
fix: show challenges as unsolved after new team joins

### DIFF
--- a/src/GZCTF/ClientApp/src/components/ChallengePanel.tsx
+++ b/src/GZCTF/ClientApp/src/components/ChallengePanel.tsx
@@ -236,8 +236,9 @@ const ChallengePanel: FC = () => {
                 }}
                 solved={
                   teamInfo &&
-                  teamInfo.rank?.challenges?.find((c) => c.id === chal.id)?.type !==
-                    SubmissionType.Unaccepted
+                  (teamInfo.rank?.challenges?.find((c) => c.id === chal.id)?.type
+                    ?? SubmissionType.Unaccepted)
+                    !== SubmissionType.Unaccepted
                 }
                 teamId={teamInfo?.rank?.id}
               />
@@ -271,8 +272,9 @@ const ChallengePanel: FC = () => {
           gameEnded={dayjs(game?.end) < dayjs()}
           solved={
             teamInfo &&
-            teamInfo.rank?.challenges?.find((c) => c.id === challenge?.id)?.type !==
-              SubmissionType.Unaccepted
+            (teamInfo.rank?.challenges?.find((c) => c.id === challenge?.id)?.type
+              ?? SubmissionType.Unaccepted)
+              !== SubmissionType.Unaccepted
           }
           tagData={challengeTagLabelMap.get((challenge?.tag as ChallengeTag) ?? ChallengeTag.Misc)!}
           title={challenge?.title ?? ''}


### PR DESCRIPTION
**问题描述：** 在新队伍报名参赛后，立即进入题目页面，看到所有题目显示为已解出。

**原因：** 积分榜还没有刷新，不含新队伍的记录，GameDetailModel.rank.challenges 为空数组，所以每道题 type 都是 undefined 而不是 SubmissionType.Unaccepted。

**解决方案：** 将 undefined 视为 SubmissionType.Unaccepted。

**问题截图：**

![a2ef347809f00b82525b415d327b86d0](https://github.com/user-attachments/assets/5db15ffe-0ff1-4ed2-9d9b-a60fff8dfde2)

![445750716ed43cf2eb369b4d8cd2266d](https://github.com/user-attachments/assets/2e2601b8-e7f0-4c01-b5d4-bcf26e4aa12b)
