### PR TITLE
feat(k8s): use ServiceAccount if in cluster and no config provided

### DIFF
--- a/docs/pages/deployment/k8s-only.en.mdx
+++ b/docs/pages/deployment/k8s-only.en.mdx
@@ -267,7 +267,7 @@ This article focuses on deploying GZCTF in a Kubernetes cluster. For configurati
    metadata:
      name: gzctf
      namespace: gzctf-server
-    annotations: # Enable Traefik Sticky Session
+     annotations: # Enable Traefik Sticky Session
        traefik.ingress.kubernetes.io/service.sticky.cookie: "true"
        traefik.ingress.kubernetes.io/service.sticky.cookie.name: "LB_Session"
        traefik.ingress.kubernetes.io/service.sticky.cookie.httponly: "true"

--- a/src/GZCTF/Services/Container/Provider/KubernetesProvider.cs
+++ b/src/GZCTF/Services/Container/Provider/KubernetesProvider.cs
@@ -42,15 +42,24 @@ public class KubernetesProvider : IContainerProvider<Kubernetes, KubernetesMetad
             PublicEntry = options.Value.PublicEntry
         };
 
-        if (!File.Exists(_kubernetesMetadata.Config.KubeConfig))
+        KubernetesClientConfiguration config;
+        
+        if (File.Exists(_kubernetesMetadata.Config.KubeConfig))
+        {
+            config = KubernetesClientConfiguration.BuildConfigFromConfigFile(_kubernetesMetadata.Config.KubeConfig);
+        }
+        else if (KubernetesClientConfiguration.IsInCluster())
+        {
+            // use ServiceAccount token if running in cluster and no kubeconfig is provided
+            config = KubernetesClientConfiguration.InClusterConfig();
+        }
+        else
         {
             logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerProvider_KubernetesConfigLoadFailed),
                 _kubernetesMetadata.Config.KubeConfig]);
             throw new FileNotFoundException(_kubernetesMetadata.Config.KubeConfig);
         }
-
-        var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(_kubernetesMetadata.Config.KubeConfig);
-
+        
         _kubernetesMetadata.HostIp = new Uri(config.Host).Host;
 
         _kubernetesClient = new Kubernetes(config);


### PR DESCRIPTION
A `ClusterRoleBinding` for a separate `ServiceAccount` is required, which should still be more elegant than pass a `kube-config.yaml` to pod.

```
apiVersion: v1
kind: ServiceAccount
metadata:
  name: gzctf-sa
  namespace: gzctf-server
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: gzctf-crb
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
  - kind: ServiceAccount
    name: gzctf-sa
    namespace: gzctf-server
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: gzctf
  namespace: gzctf-server
  labels:
    app: gzctf
spec:
...
    spec:
      serviceAccountName: gzctf-sa
...
```
