### PR TITLE
fix(team create): only create one team

### DIFF
--- a/src/GZCTF/Controllers/TeamController.cs
+++ b/src/GZCTF/Controllers/TeamController.cs
@@ -94,7 +94,7 @@ public partial class TeamController(
 
         Team[] teams = await teamRepository.GetUserTeams(user!, token);
 
-        if (teams.Length > 1 && teams.Any(t => t.CaptainId == user!.Id))
+        if (teams.Length > 0 && teams.Any(t => t.CaptainId == user!.Id))
             return BadRequest(
                 new RequestResponse(localizer[nameof(Resources.Program.Team_MultipleCreationNotAllowed)]));
 


### PR DESCRIPTION
`        if (teams.Length > 1 && teams.Any(t => t.CaptainId == user!.Id))
            return BadRequest(
                new RequestResponse(localizer[nameof(Resources.Program.Team_MultipleCreationNotAllowed)]));
`

this code allow user create two team, so we fixed it...