### PR TITLE
feat(games): allow pagination in games

### DIFF
--- a/src/GZCTF/ClientApp/src/Api.ts
+++ b/src/GZCTF/ClientApp/src/Api.ts
@@ -1166,6 +1166,18 @@ export enum TaskStatus {
   Pending = "Pending",
 }
 
+export interface PaginationResponseOfBasicGameInfoModel {
+  data?: BasicGameInfoModel[];
+  /** @format int32 */
+  page?: number;
+  /** @format int32 */
+  pageSize?: number;
+  /** @format int32 */
+  total?: number;
+  /** @format int32 */
+  totalPage?: number;
+}
+
 /** Basic game information, excluding detailed description and current team registration status */
 export interface BasicGameInfoModel {
   /** @format int32 */
@@ -1979,7 +1991,6 @@ export class HttpClient<SecurityDataType = unknown> {
   };
 }
 
-import { handleAxiosError } from "@Utils/ApiHelper";
 import useSWR, { MutatorOptions, SWRConfiguration, mutate } from "swr";
 
 /**
@@ -3867,41 +3878,73 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     ) => mutate<DetailedGameInfoModel>(`/api/game/${id}`, data, options),
 
     /**
-     * @description Retrieves the latest ten games
+     * @description Retrieves games with pagination
      *
      * @tags Game
      * @name GameGamesAll
      * @summary Get the latest games
      * @request GET:/api/game
      */
-    gameGamesAll: (params: RequestParams = {}) =>
-      this.request<BasicGameInfoModel[], RequestResponse>({
+    gameGamesAll: (
+      query?: {
+        /**
+         * Page Number
+         * @format int32
+         * @default 0
+         */
+        page?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<PaginationResponseOfBasicGameInfoModel, RequestResponse>({
         path: `/api/game`,
         method: "GET",
+        query: query,
         format: "json",
         ...params,
       }),
     /**
-     * @description Retrieves the latest ten games
+     * @description Retrieves games with pagination
      *
      * @tags Game
      * @name GameGamesAll
      * @summary Get the latest games
      * @request GET:/api/game
      */
-    useGameGamesAll: (options?: SWRConfiguration, doFetch: boolean = true) =>
-      useSWR<BasicGameInfoModel[], RequestResponse>(doFetch ? `/api/game` : null, options),
+    useGameGamesAll: (
+      query?: {
+        /**
+         * Page Number
+         * @format int32
+         * @default 0
+         */
+        page?: number;
+      },
+      options?: SWRConfiguration,
+      doFetch: boolean = true,
+    ) =>
+      useSWR<PaginationResponseOfBasicGameInfoModel, RequestResponse>(doFetch ? [`/api/game`, query] : null, options),
 
     /**
-     * @description Retrieves the latest ten games
+     * @description Retrieves games with pagination
      *
      * @tags Game
      * @name GameGamesAll
      * @summary Get the latest games
      * @request GET:/api/game
      */
-    mutateGameGamesAll: (data?: BasicGameInfoModel[] | Promise<BasicGameInfoModel[]>, options?: MutatorOptions) =>
-      mutate<BasicGameInfoModel[]>(`/api/game`, data, options),
+    mutateGameGamesAll: (
+      query?: {
+        /**
+         * Page Number
+         * @format int32
+         * @default 0
+         */
+        page?: number;
+      },
+      data?: PaginationResponseOfBasicGameInfoModel | Promise<PaginationResponseOfBasicGameInfoModel>,
+      options?: MutatorOptions,
+    ) => mutate<PaginationResponseOfBasicGameInfoModel>([`/api/game`, query], data, options),
 
     /**
      * @description Downloads all traffic packet files for a team and challenge; requires Monitor permission

--- a/src/GZCTF/ClientApp/src/pages/Index.tsx
+++ b/src/GZCTF/ClientApp/src/pages/Index.tsx
@@ -21,11 +21,12 @@ const Home: FC = () => {
     refreshInterval: 5 * 60 * 1000,
   })
 
-  const { data: allGames } = api.game.useGameGamesAll({
+  const { data: allGamesResponse } = api.game.useGameGamesAll({},{
     refreshInterval: 5 * 60 * 1000,
   })
 
-  allGames?.sort((a, b) => new Date(a.end!).getTime() - new Date(b.end!).getTime())
+  const allGames = allGamesResponse?.data;
+  allGames?.sort((a, b) => new Date(a.end!).getTime() - new Date(b.end!).getTime());
 
   const onTogglePinned = async (post: PostInfoModel, setDisabled: (value: boolean) => void) => {
     setDisabled(true)

--- a/src/GZCTF/ClientApp/src/pages/games/Index.tsx
+++ b/src/GZCTF/ClientApp/src/pages/games/Index.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@mantine/core'
-import { FC } from 'react'
+import { Center, Pagination, Stack } from '@mantine/core'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { GameCard } from '@Components/GameCard'
 import { WithNavBar } from '@Components/WithNavbar'
@@ -7,11 +7,20 @@ import { OnceSWRConfig } from '@Hooks/useConfig'
 import { usePageTitle } from '@Hooks/usePageTitle'
 import api from '@Api'
 
+
 const Games: FC = () => {
   const { t } = useTranslation()
+  const [page, setPage] = useState(1)
 
-  const { data: allGames } = api.game.useGameGamesAll(OnceSWRConfig)
+  const { data: allGamesResponse, mutate } = api.game.useGameGamesAll({
+    page: page
+  }, OnceSWRConfig)
 
+  useEffect(() => {
+    mutate()
+  }, [page, mutate])
+
+  const allGames = allGamesResponse?.data
   allGames?.sort((a, b) => new Date(a.end!).getTime() - new Date(b.end!).getTime())
 
   const now = new Date()
@@ -23,11 +32,18 @@ const Games: FC = () => {
   usePageTitle(t('game.title.index'))
 
   return (
-    <WithNavBar withHeader stickyHeader>
+    <WithNavBar minWidth={0} withHeader stickyHeader>
       <Stack>
-        {games.map((g) => (
-          <GameCard key={g.id} game={g} />
-        ))}
+        <Stack mih='calc(100vh - 140px)'>
+          {games.map((g) => (
+            <GameCard key={g.id} game={g} />
+          ))}
+        </Stack>
+        <footer style={{ marginBottom: '1rem' }}>
+          <Center>
+            <Pagination total={allGamesResponse?.totalPage ?? 0} value={page} onChange={setPage} />
+          </Center>
+        </footer>
       </Stack>
     </WithNavBar>
   )

--- a/src/GZCTF/Repositories/GameRepository.cs
+++ b/src/GZCTF/Repositories/GameRepository.cs
@@ -46,13 +46,13 @@ public class GameRepository(
                                  && g.StartTimeUtc - DateTime.UtcNow < TimeSpan.FromMinutes(15))
             .OrderBy(g => g.StartTimeUtc).Select(g => g.Id).ToArrayAsync(token);
 
-    public async Task<BasicGameInfoModel[]> GetBasicGameInfo(int count = 10, int skip = 0,
-        CancellationToken token = default) =>
+    public async Task<BasicGameInfoModel[]> GetBasicGameInfo(CancellationToken token = default) =>
         await cache.GetOrCreateAsync(logger, CacheKey.BasicGameInfo, entry =>
         {
             entry.SlidingExpiration = TimeSpan.FromHours(2);
             return Context.Games.Where(g => !g.Hidden)
-                .OrderByDescending(g => g.StartTimeUtc).Skip(skip).Take(count)
+                .OrderByDescending(g => g.StartTimeUtc)
+                .Take(100) // limit to 100 games
                 .Select(g => BasicGameInfoModel.FromGame(g)).ToArrayAsync(token);
         }, token);
 

--- a/src/GZCTF/Repositories/Interface/IGameRepository.cs
+++ b/src/GZCTF/Repositories/Interface/IGameRepository.cs
@@ -11,7 +11,7 @@ public interface IGameRepository : IRepository
     /// <param name="skip"></param>
     /// <param name="token"></param>
     /// <returns></returns>
-    public Task<BasicGameInfoModel[]> GetBasicGameInfo(int count = 10, int skip = 0, CancellationToken token = default);
+    public Task<BasicGameInfoModel[]> GetBasicGameInfo(CancellationToken token = default);
 
     /// <summary>
     /// 获取指定数量的比赛对象

--- a/src/GZCTF/Utils/Shared.cs
+++ b/src/GZCTF/Utils/Shared.cs
@@ -38,6 +38,19 @@ public record RequestResponse(string Title, int Status = StatusCodes.Status400Ba
 public record RequestResponse<T>(string Title, T Data, int Status = StatusCodes.Status400BadRequest);
 
 /// <summary>
+/// Pagination response
+/// </summary>
+/// <typeparam name="T">Data type</typeparam>
+/// <param name="Data">Data</param>
+/// <param name="Page">Current page</param>
+/// <param name="PageSize">Page size</param>
+/// <param name="Total">Total data count</param>
+public record PaginationResponse<T>(T[] Data, int Page, int PageSize, int Total)
+{
+    public int TotalPage => (Total + PageSize - 1) / PageSize;
+}
+
+/// <summary>
 /// Answer verification result
 /// </summary>
 /// <param name="SubType">Submission type</param>


### PR DESCRIPTION
## Motivation

It can only show up to 10 games in the game list. Instances with 10 more games (e.g. https://gz.imxbt.cn) will hide former games.

## Changes

* Add pagination in the `/games` endpoint, with a query parameter: `page`. 
* Fix wrong caching with ignore skip in `GetBasicGameInfo` (btw. it's a bad name)
* Add a Pagination Control

After:

![image](https://github.com/user-attachments/assets/ab014399-d8d1-4eb8-ae55-0da6e326d25c)

## To-dos

* Tweak UI

## Assignees

@kengwang @GZTimeWalker 