### PR TITLE
chore: better tsconfig

### DIFF
--- a/src/GZCTF/ClientApp/tsconfig.app.json
+++ b/src/GZCTF/ClientApp/tsconfig.app.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "baseUrl": ".",
+    "incremental": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "paths": {
+      "@Api": ["src/Api.ts"],
+      "@App": ["src/App"],
+      "@Components/*": ["src/components/*"],
+      "@Hooks/*": ["src/hooks/*"],
+      "@Pages/*": ["src/pages/*"],
+      "@Resources/*": ["src/resources/*"],
+      "@Styles/*": ["src/styles/components/*", "src/styles/shared/*", "src/styles/pages/*"],
+      "@Utils/*": ["src/utils/*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/src/GZCTF/ClientApp/tsconfig.json
+++ b/src/GZCTF/ClientApp/tsconfig.json
@@ -1,33 +1,7 @@
 {
-  "compilerOptions": {
-    "allowJs": false,
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "incremental": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "esnext",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "paths": {
-      "@Api": ["src/Api.ts"],
-      "@App": ["src/App"],
-      "@Components/*": ["src/components/*"],
-      "@Hooks/*": ["src/hooks/*"],
-      "@Pages/*": ["src/pages/*"],
-      "@Resources/*": ["src/resources/*"],
-      "@Styles/*": ["src/styles/components/*", "src/styles/shared/*", "src/styles/pages/*"],
-      "@Utils/*": ["src/utils/*"]
-    },
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "esnext",
-    "types": ["vite/client"]
-  },
-  "exclude": ["node_modules"],
-  "include": ["vite.config.mts", "**/*.ts", "**/*.tsx"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
 }

--- a/src/GZCTF/ClientApp/tsconfig.node.json
+++ b/src/GZCTF/ClientApp/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "incremental": true,
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["plugins", "postcss.config.*", "prettier.config.*", "vite.config.*"]
+}


### PR DESCRIPTION
要点 1：浏览器环境的代码和 node 环境的代码要隔离 tsconfig
要点 2：浏览器环境的代码设置 `"types": []` 不期望的自动类型导入