### PR TITLE
fix(batch-user-create): correct validation to use MaxTeamNameLength

### DIFF
--- a/src/GZCTF/Models/Request/Admin/UserCreateModel.cs
+++ b/src/GZCTF/Models/Request/Admin/UserCreateModel.cs
@@ -58,7 +58,7 @@ public class UserCreateModel
     /// <summary>
     /// Team the user joins
     /// </summary>
-    [MaxLength(Limits.MaxUserNameLength, ErrorMessageResourceName = nameof(Resources.Program.Model_TeamNameTooLong),
+    [MaxLength(Limits.MaxTeamNameLength, ErrorMessageResourceName = nameof(Resources.Program.Model_TeamNameTooLong),
         ErrorMessageResourceType = typeof(Resources.Program))]
     public string? TeamName { get; set; }
 


### PR DESCRIPTION
Previously, the batch user creation flow was using `MaxUserNameLength` for validating **team name**, which is incorrect.
This PR updates the validation to use `MaxTeamNameLength` instead.

### Changes

* Replaced `MaxUserNameLength` with `MaxTeamNameLength` in validation attribute
* Error message remains the same (`Model_TeamNameTooLong`)

### Impact

* Ensures team name validation respects the correct maximum length
* Prevents incorrect validation errors when creating users in batch