### PR TITLE
fix(frontend): exclude isPinned from post update payload

### DIFF
--- a/src/GZCTF/ClientApp/src/pages/posts/[postId]/Edit.tsx
+++ b/src/GZCTF/ClientApp/src/pages/posts/[postId]/Edit.tsx
@@ -89,7 +89,11 @@ const PostEdit: FC = () => {
       setDisabled(true)
 
       try {
-        const res = await api.edit.editUpdatePost(postId, post)
+        // Temporary workaround for an issue where posts could not be updated.
+        // Ideally, the pin/unpin functionality should be handled by a separate API endpoint.
+        const { isPinned, ...postWithoutPin } = post
+        
+        const res = await api.edit.editUpdatePost(postId, postWithoutPin)
         api.info.mutateInfoGetPost(postId, res.data)
         api.info.mutateInfoGetLatestPosts()
         api.info.mutateInfoGetPosts()


### PR DESCRIPTION
This is a temporary fix for an issue where post updates were ignored when the `isPinned` field was present in the request body. It seems like the pin/unpin logic should be moved to a separate API endpoint to properly separate “editing post content” from “toggling pinned status.”
