### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,17 +2,17 @@
 
 ## Supported Versions
 
-Security updates are provided for:
+Security updates are provided for the following versions:
 
 | Version | Supported |
 | --- | --- |
-| Latest release | :white_check_mark: |
+| Latest stable release | :white_check_mark: |
 | `develop` branch | :white_check_mark: |
 | Older versions | :x: |
 
 ## Reporting a Vulnerability
 
-Please report vulnerabilities through **GitHub Private Vulnerability Reporting**:
+Please report vulnerabilities through **GitHub Private Vulnerability Reporting**.
 
 1. Open the repository on GitHub.
 2. Go to the **Security** tab.
@@ -20,9 +20,10 @@ Please report vulnerabilities through **GitHub Private Vulnerability Reporting**
 
 Please do **not** open public issues for security reports.
 
-When reporting, include:
-- Affected version/commit
-- Reproduction steps or PoC
+### Include in your report
+
+- Affected version or commit
+- Clear reproduction steps and/or PoC
 - Impact assessment
 - Suggested fix (if available)
 
@@ -34,18 +35,21 @@ When reporting, include:
 
 ## Disclosure Policy
 
-- We follow coordinated disclosure.
-- Please keep details private until a fix is available.
-- We aim to publish an advisory/CVE after remediation.
-- If a fix is delayed, we may coordinate a disclosure timeline (target: up to **90 days**).
+We follow coordinated disclosure:
+
+- Keep details private until a fix is available.
+- Publish an advisory and/or CVE after remediation when appropriate.
+- If remediation is delayed, coordinate a disclosure timeline (target: up to **90 days**).
 
 ## Safe Harbor
 
 If you act in good faith and follow this policy, we will not pursue legal action for:
+
 - Security research intended to improve project security
 - Non-destructive testing that avoids privacy violations and service disruption
 
 Please avoid:
+
 - Data exfiltration, persistence, or privilege abuse beyond proving impact
 - Denial-of-service and large-scale automated scanning
 - Any action that harms users, infrastructure, or data


### PR DESCRIPTION
## Summary
- add a repository-level SECURITY.md policy
- define private vulnerability reporting via GitHub Security Advisories
- document response SLA, coordinated disclosure expectations, and safe-harbor guidance
- include supported-version scope

## Why
A dedicated security policy makes it possible to report vulnerabilities responsibly and privately instead of opening public issues.