### PR TITLE
chore: change default Admin email to a 100% invalid address

### DIFF
--- a/src/GZCTF/Utils/PrelaunchHelper.cs
+++ b/src/GZCTF/Utils/PrelaunchHelper.cs
@@ -54,7 +54,7 @@ public static class PrelaunchHelper
                     admin = new UserInfo
                     {
                         UserName = "Admin",
-                        Email = "admin@example.com",
+                        Email = "admin@example.invalid",
                         Role = Role.Admin,
                         EmailConfirmed = true,
                         RegisterTimeUtc = DateTimeOffset.UtcNow


### PR DESCRIPTION
This pull request makes a small update to the admin user email address in the `PrelaunchHelper.cs` utility. The email for the default admin user has been changed from a real-looking address to a generic placeholder.

* Changed the default admin user's email from `"admin@gzti.me"` to `"admin@example.com"` in `src/GZCTF/Utils/PrelaunchHelper.cs`.