### PR TITLE
Add new Container-Manager that launches Docker Compose files

### DIFF
--- a/samples/compose/compose.yml
+++ b/samples/compose/compose.yml
@@ -1,0 +1,55 @@
+services:
+  gzctf:
+    image: gztime/gzctf:latest
+    restart: unless-stopped
+    environment:
+      - "ADMIN_PASSWORD=Admin@1Test"
+      - "LC_ALL=en_US.UTF-8"
+    ports:
+      - "8081:8080"
+    volumes:
+      - "gzctf-files:/app/files"
+      - "./settings.json:/app/appsettings.json:ro"
+      - "docker-socket:/run"
+    depends_on:
+      - db
+
+  db:
+    image: postgres:18
+    restart: unless-stopped
+    environment:
+      - "POSTGRES_PASSWORD=PgAdminPwBla"
+    volumes:
+      - "db-data:/var/lib/postgresql"
+
+  dind:
+    build:
+      context: .
+      pull: true
+      dockerfile_inline: |
+        FROM docker:dind-rootless
+        USER root
+        RUN sed -i -e 's/^rootless:x:1000:1000:/rootless:x:895:895:/' /etc/passwd && \
+            sed -i -e 's/^rootless:x:1000:/rootless:x:895:/' /etc/group && \
+            chown -R rootless:rootless ~rootless
+        USER rootless
+    restart: unless-stopped
+    privileged: true
+    network_mode: host
+    command: dockerd --host=unix:///run/docker/docker.sock --group 897
+    volumes:
+      - "docker-socket:/run/docker"
+      - "docker-data:/var/lib/docker"
+      - "docker-user-data:/home/rootless/.local/share/docker"
+
+volumes:
+  docker-socket:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=16m,mode=1777,nosuid,nodev
+  docker-data:
+  docker-user-data:
+  gzctf-files:
+  db-data:

--- a/samples/compose/settings.json
+++ b/samples/compose/settings.json
@@ -1,0 +1,38 @@
+{
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Database": "Host=db:5432;Database=gzctf;Username=postgres;Password=PgAdminPwBla"
+  },
+  "EmailConfig": {
+    "SenderAddress": "",
+    "SenderName": "",
+    "UserName": "",
+    "Password": "",
+    "Smtp": {
+      "Host": "localhost",
+      "Port": 587
+    }
+  },
+  "XorKey": "e35tgWET5zhgw4twea45rtgWASEFwaESFGSRGH",
+  "ContainerProvider": {
+    "Type": "DockerCompose", // or "Kubernetes"
+    "PortMappingType": "Default", // or "PlatformProxy"
+    "EnableTrafficCapture": false,
+    "PublicEntry": "127.0.0.1", // or "xxx.xxx.xxx.xxx"
+    // optional
+    "DockerConfig": {
+      "SwarmMode": false,
+      "Uri": "unix:///run/docker.sock"
+    }
+  },
+  "CaptchaConfig": {
+    "Provider": "None", // or "CloudflareTurnstile" or "HashPow"
+    "SiteKey": "<Your SITE_KEY>",
+    "SecretKey": "<Your SECRET_KEY>"
+  },
+  "ForwardedOptions": {
+    "ForwardedHeaders": 7,
+    "ForwardLimit": 1,
+    "TrustedNetworks": ["192.168.12.0/8"]
+  }
+}

--- a/src/GZCTF/ClientApp/src/Api.ts
+++ b/src/GZCTF/ClientApp/src/Api.ts
@@ -136,6 +136,12 @@ export enum TaskStatus {
   Pending = "Pending",
 }
 
+export enum ContainerProviderType {
+  Docker = "Docker",
+  Kubernetes = "Kubernetes",
+  DockerCompose = "DockerCompose",
+}
+
 /** User role enumeration */
 export enum Role {
   Banned = "Banned",
@@ -348,6 +354,12 @@ export interface ProfileUserInfoModel {
   stdNumber?: string | null;
   /** Avatar URL */
   avatar?: string | null;
+}
+
+/** Global Container Provider Settings */
+export interface ContainerProviderModel {
+  /** Container Provider Type */
+  type?: ContainerProviderType;
 }
 
 /** Global configuration update */
@@ -2830,6 +2842,56 @@ export class Api<
       data?: ConfigEditModel | Promise<ConfigEditModel>,
       options?: MutatorOptions,
     ) => mutate<ConfigEditModel>(`/api/admin/config`, data, options),
+
+    /**
+     * @description Use this API to get the current ContainerProvider config, requires Admin permission
+     *
+     * @tags Admin
+     * @name AdminGetContainerProvider
+     * @summary Get container provider
+     * @request GET:/api/admin/containerprovider
+     */
+    adminGetContainerProvider: (params: RequestParams = {}) =>
+      this.request<ContainerProviderModel, RequestResponse>({
+        path: `/api/admin/containerprovider`,
+        method: "GET",
+        format: "json",
+        ...params,
+      }),
+    /**
+     * @description Use this API to get the current ContainerProvider config, requires Admin permission
+     *
+     * @tags Admin
+     * @name AdminGetContainerProvider
+     * @summary Get container provider
+     * @request GET:/api/admin/containerprovider
+     */
+    useAdminGetContainerProvider: (
+      options?: SWRConfiguration,
+      doFetch: boolean = true,
+    ) =>
+      useSWR<ContainerProviderModel, RequestResponse>(
+        doFetch ? `/api/admin/containerprovider` : null,
+        options,
+      ),
+
+    /**
+     * @description Use this API to get the current ContainerProvider config, requires Admin permission
+     *
+     * @tags Admin
+     * @name AdminGetContainerProvider
+     * @summary Get container provider
+     * @request GET:/api/admin/containerprovider
+     */
+    mutateAdminGetContainerProvider: (
+      data?: ContainerProviderModel | Promise<ContainerProviderModel>,
+      options?: MutatorOptions,
+    ) =>
+      mutate<ContainerProviderModel>(
+        `/api/admin/containerprovider`,
+        data,
+        options,
+      ),
 
     /**
      * @description Use this API to get all container instances, requires Admin permission

--- a/src/GZCTF/ClientApp/src/locales/de-DE/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/de-DE/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Kategorie",
         "container_image": "Container-Image",
+        "container_compose": "Compose-Script oder Image-Name",
         "cpu_limit": {
           "description": "Multiplikation von 0,1 CPU-Kern",
           "label": "CPU-Limit (0,1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/en-US/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/en-US/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Category",
         "container_image": "Container Image",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Multiplication of 0.1 CPU core",
           "label": "CPU Limit (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/es-ES/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/es-ES/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Categoría",
         "container_image": "Imagen del Contenedor",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Multiplicación de 0.1 núcleo de CPU",
           "label": "Límite de CPU (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/fr-FR/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/fr-FR/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Catégorie",
         "container_image": "Image du Conteneur",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Multiplication de 0.1 cœur CPU",
           "label": "Limite CPU (0,1 CPU)"

--- a/src/GZCTF/ClientApp/src/locales/id-ID/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/id-ID/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Kategori",
         "container_image": "Container image",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Multiplication of 0.1 CPU core",
           "label": "CPU Limit (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/ja-JP/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/ja-JP/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "カテゴリ",
         "container_image": "コンテナイメージ",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "0.1を掛けると、CPUのコア数になります",
           "label": "CPU 制限 (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/ko-KR/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/ko-KR/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "분야",
         "container_image": "컨테이너 이미지",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "0.1 CPU 코어 개수",
           "label": "CPU 제한 (단위: 0.1 CPU)"

--- a/src/GZCTF/ClientApp/src/locales/ru-RU/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/ru-RU/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Категория",
         "container_image": "Образ контейнера",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Макс. нагрузка на ядра",
           "label": "Лимит ЦП (0.1 ядра)"

--- a/src/GZCTF/ClientApp/src/locales/vi-VN/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/vi-VN/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "Danh mục",
         "container_image": "Container Image",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "Bội của 0.1 CPU",
           "label": "CPU Limit (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/zh-CN/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/zh-CN/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "题目类别",
         "container_image": "容器镜像",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "乘以 0.1 即为 CPU 核心数",
           "label": "CPU 限制 (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/locales/zh-TW/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/zh-TW/admin.json
@@ -108,6 +108,7 @@
         },
         "category": "題目類別",
         "container_image": "容器鏡像",
+        "container_compose": "Compose Script or Image Name",
         "cpu_limit": {
           "description": "乘以 0.1 即為 CPU 核心數",
           "label": "CPU 限制 (0.1 CPUs)"

--- a/src/GZCTF/ClientApp/src/pages/admin/games/[id]/challenges/[chalId]/Index.tsx
+++ b/src/GZCTF/ClientApp/src/pages/admin/games/[id]/challenges/[chalId]/Index.tsx
@@ -39,8 +39,11 @@ import {
 } from '@Utils/Shared'
 import { useEditChallenge, useEditChallenges } from '@Hooks/useEdit'
 import { useGame } from '@Hooks/useGame'
-import api, { ChallengeCategory, ChallengeType, ChallengeUpdateModel, NetworkMode } from '@Api'
+import api, { ChallengeCategory, ChallengeType, ChallengeUpdateModel, ContainerProviderType, NetworkMode } from '@Api'
 import misc from '@Styles/Misc.module.css'
+
+// This will never change at runtime, so just hard-cache it
+let cachedContainerProvider: ContainerProviderType | null = null
 
 const GameChallengeEdit: FC = () => {
   const navigate = useNavigate()
@@ -64,6 +67,7 @@ const GameChallengeEdit: FC = () => {
   const [type, setType] = useState<string | null>(challenge?.type ?? ChallengeType.StaticAttachment)
   const [currentAcceptCount, setCurrentAcceptCount] = useState(0)
   const [previewOpened, setPreviewOpened] = useState(false)
+  const [containerProvider, setContainerProvider] = useState<ContainerProviderType | null>(cachedContainerProvider);
 
   const modals = useModals()
   const challengeTypeLabelMap = useChallengeTypeLabelMap()
@@ -81,6 +85,18 @@ const GameChallengeEdit: FC = () => {
       setCurrentAcceptCount(challenge.acceptedCount)
     }
   }, [challenge])
+
+  useEffect(() => {
+    if (cachedContainerProvider !== null)
+      return
+
+    api.admin.adminGetContainerProvider()
+      .then(res => {
+        cachedContainerProvider = res.data.type ?? null
+        setContainerProvider(cachedContainerProvider)
+      })
+      .catch(() => setContainerProvider(cachedContainerProvider))
+  }, [])
 
   const onUpdate = async (challenge: ChallengeUpdateModel, noFeedback?: boolean) => {
     if (!challenge) return
@@ -466,14 +482,26 @@ const GameChallengeEdit: FC = () => {
           <Grid columns={12}>
             <Grid.Col span={8}>
               <Group justify="space-between" align="flex-end">
-                <TextInput
-                  label={t('admin.content.games.challenges.container_image')}
-                  disabled={disabled}
-                  value={challengeInfo.containerImage ?? ''}
-                  required
-                  onChange={(e) => setChallengeInfo({ ...challengeInfo, containerImage: e.target.value })}
-                  classNames={{ root: misc.flexGrow }}
-                />
+                {(containerProvider == ContainerProviderType.DockerCompose) && (
+                  <Textarea
+                    label={t('admin.content.games.challenges.container_compose')}
+                    disabled={disabled}
+                    value={challengeInfo.containerImage ?? ''}
+                    required
+                    onChange={(e) => setChallengeInfo({ ...challengeInfo, containerImage: e.target.value })}
+                    classNames={{ root: misc.flexGrow }}
+                    styles={{ input: { resize: 'vertical' } }}
+                  />
+                ) || (
+                  <TextInput
+                    label={t('admin.content.games.challenges.container_image')}
+                    disabled={disabled}
+                    value={challengeInfo.containerImage ?? ''}
+                    required
+                    onChange={(e) => setChallengeInfo({ ...challengeInfo, containerImage: e.target.value })}
+                    classNames={{ root: misc.flexGrow }}
+                  />
+                )}
                 <NumberInput
                   label={t('admin.content.games.challenges.service_port.label')}
                   min={1}

--- a/src/GZCTF/Controllers/AdminController.cs
+++ b/src/GZCTF/Controllers/AdminController.cs
@@ -43,6 +43,27 @@ public class AdminController(
     IStringLocalizer<Program> localizer) : ControllerBase
 {
     /// <summary>
+    /// Get container provider
+    /// </summary>
+    /// <remarks>
+    /// Use this API to get the current ContainerProvider config, requires Admin permission
+    /// </remarks>
+    /// <response code="200">Name of the container backend in use</response>
+    /// <response code="401">Unauthorized user</response>
+    /// <response code="403">Forbidden</response>
+    [HttpGet("ContainerProvider")]
+    [ProducesResponseType(typeof(ContainerProviderModel), StatusCodes.Status200OK)]
+    public IActionResult GetContainerProvider()
+    {
+        ContainerProviderModel containerProvider = new()
+        {
+            Type = serviceProvider.GetRequiredService<IOptionsSnapshot<ContainerProvider>>().Value.Type
+        };
+
+        return Ok(containerProvider);
+    }
+
+    /// <summary>
     /// Get configuration
     /// </summary>
     /// <remarks>

--- a/src/GZCTF/Dockerfile
+++ b/src/GZCTF/Dockerfile
@@ -10,7 +10,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
 
 WORKDIR /app
 RUN apk add --update --no-cache wget libpcap icu-data-full icu-libs \
-    ca-certificates libgdiplus tzdata krb5-libs && \
+    ca-certificates libgdiplus tzdata krb5-libs docker-cli docker-cli-compose && \
     update-ca-certificates
 
 COPY --from=build --chown=$APP_UID:$APP_UID /publish .

--- a/src/GZCTF/Models/Internal/Configs.cs
+++ b/src/GZCTF/Models/Internal/Configs.cs
@@ -400,7 +400,8 @@ public class EmailConfig
 public enum ContainerProviderType
 {
     Docker,
-    Kubernetes
+    Kubernetes,
+    DockerCompose
 }
 
 [JsonConverter(typeof(JsonStringEnumConverter<ContainerPortMappingType>))]
@@ -442,8 +443,10 @@ public class KubernetesConfig
 public class RegistrySet<T> : Dictionary<string, T>
     where T : class
 {
-    public T? GetForImage(string image)
+    public T? GetForImage(string image, out string registry)
     {
+        registry = "";
+
         if (string.IsNullOrWhiteSpace(image))
             return null;
 
@@ -452,8 +455,25 @@ public class RegistrySet<T> : Dictionary<string, T>
         if (!Uri.TryCreate(image, UriKind.Absolute, out var uri) || uri.HostNameType == UriHostNameType.Unknown)
             return null;
 
-        return TryGetValue(uri.Authority, out var cfg) ? cfg :
-            TryGetValue(uri.Host, out var cfgHost) ? cfgHost : null;
+        if (TryGetValue(uri.Authority, out var cfg))
+        {
+            registry = uri.Authority;
+            return cfg;
+        }
+
+
+        if (TryGetValue(uri.Host, out var cfgHost))
+        {
+            registry = uri.Host;
+            return cfgHost;
+        }
+
+        return null;
+    }
+
+    public T? GetForImage(string image)
+    {
+        return GetForImage(image, out var registry);
     }
 }
 

--- a/src/GZCTF/Models/Request/Admin/ContainerProviderModel.cs
+++ b/src/GZCTF/Models/Request/Admin/ContainerProviderModel.cs
@@ -1,0 +1,14 @@
+﻿using GZCTF.Models.Internal;
+
+namespace GZCTF.Models.Request.Admin;
+
+/// <summary>
+/// Global Container Provider Settings
+/// </summary>
+public class ContainerProviderModel
+{
+    /// <summary>
+    /// Container Provider Type
+    /// </summary>
+    public ContainerProviderType Type { get; set; }
+}

--- a/src/GZCTF/Resources/Program.de-DE.resx
+++ b/src/GZCTF/Resources/Program.de-DE.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Fehler beim Erstellen des Containers {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Fehler beim Erstellen des Containers {0}, Antwort: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Fehler beim Erstellen des Containers {0}, Status: {1}</value>
@@ -349,6 +367,9 @@
     </value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Containermodus: Docker-Instanz-Containersteuerung</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Containermodus: Docker-Instanz-Containersteuerung</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.es-ES.resx
+++ b/src/GZCTF/Resources/Program.es-ES.resx
@@ -313,8 +313,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Error al crear el contenedor {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Error al crear el contenedor {0}, respuesta: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Error al crear el contenedor {0}, estado: {1}</value>
@@ -350,6 +368,9 @@
     </value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Modo de contenedor: Controles de contenedor de instancia Docker</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Modo de contenedor: Controles de contenedor de instancia Docker</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.fr-FR.resx
+++ b/src/GZCTF/Resources/Program.fr-FR.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Échec de création du conteneur {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Échec de création du conteneur {0}, réponse : {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Échec de création du conteneur {0}, statut : {1}</value>
@@ -347,6 +365,9 @@
     </value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Mode conteneur：Contrôles de conteneur d'instance Docker</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Mode conteneur：Contrôles de conteneur d'instance Docker</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.id-ID.resx
+++ b/src/GZCTF/Resources/Program.id-ID.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Gagal membuat container {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Gagal membuat container {0}, response: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Gagal membuat container {0}, status: {1}</value>
@@ -345,6 +363,9 @@
     <value>Gagal mendapatkan informasi eksposur port setelah kontainer {0} dibuat</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Mode container ： kontrol container instance docker instance</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Mode container ： kontrol container instance docker instance</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.ja-JP.resx
+++ b/src/GZCTF/Resources/Program.ja-JP.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>コンテナ {0} を作成できませんでした</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>コンテナ {0} を作成できませんでした、レスポンス：{1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>コンテナ {0} を作成できませんでした、ステータス：{1}</value>
@@ -345,6 +363,9 @@
     <value>コンテナ{0} のポート情報を取得できませんでしたため作成に失敗しました</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>コンテナ管理モード：Docker 単一インスタンスコンテナー制御</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>コンテナ管理モード：Docker 単一インスタンスコンテナー制御</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.ko-KR.resx
+++ b/src/GZCTF/Resources/Program.ko-KR.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>컨테이너 생성 실패 {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>컨테이너 생성 실패 {0}, 응답: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>컨테이너 생성 실패 {0}, status: {1}</value>
@@ -345,6 +363,9 @@
     <value>{0} 컨테이너 생성 후 외부 port 연결에 실패했습니다.</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>컨테이너 모드: Docker Instance 컨테이너 제어</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>컨테이너 모드: Docker Instance 컨테이너 제어</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.resx
+++ b/src/GZCTF/Resources/Program.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Failed to create container {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Failed to create container {0}, response: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Failed to create container {0}, status: {1}</value>
@@ -346,6 +364,9 @@
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
     <value>Container mode：Docker Instance Container Controls</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
+    <value>Container Mode：Docker Compose Instance Container Controls</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">
     <value>Container Mode：K8s Cluster Pod Container Control</value>

--- a/src/GZCTF/Resources/Program.ru-RU.resx
+++ b/src/GZCTF/Resources/Program.ru-RU.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Не удалось создать контейнер {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Не удалось создать контейнер {0}, ответ: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Не удалось создать контейнер {0}, статус: {1}</value>
@@ -345,6 +363,9 @@
     <value>Не удалось получить информацию об открытии портов контейнера {0} после его создания</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Режим контейнеризации：Docker Instance Container Controls</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Режим контейнеризации：Docker Instance Container Controls</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.vi-VN.resx
+++ b/src/GZCTF/Resources/Program.vi-VN.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>Không tạo được container {0}</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>Không tạo được container {0}, phản hồi: {1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>Không tạo được container {0}, trạng thái: {1}</value>
@@ -345,6 +363,9 @@
     <value>Không lấy được thông tin port sau khi tạo container {0}</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>Container mode：Docker Instance Container Controls</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>Container mode：Docker Instance Container Controls</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.zh-CN.resx
+++ b/src/GZCTF/Resources/Program.zh-CN.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>容器 {0} 创建失败</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>容器 {0} 创建失败, 响应：{1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>容器 {0} 创建失败, 状态：{1}</value>
@@ -345,6 +363,9 @@
     <value>容器 {0} 创建后未获取到端口暴露信息，创建失败</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>容器管理模式：Docker 单实例容器控制</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>容器管理模式：Docker 单实例容器控制</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Resources/Program.zh-TW.resx
+++ b/src/GZCTF/Resources/Program.zh-TW.resx
@@ -311,8 +311,26 @@
   <data name="ContainerManager_ContainerCreationFailed" xml:space="preserve">
     <value>容器 {0} 創建失敗</value>
   </data>
+  <data name="ContainerManager_ComposeUnexpectedIDs" xml:space="preserve">
+    <value>Unexpected container IDs returned by docker compose.</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailedResponse" xml:space="preserve">
+    <value>Deleting compose project {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_ComposeDeletionFailed" xml:space="preserve">
+    <value>Failed deleting compose project {0}</value>
+  </data>
+  <data name="ContainerManager_ComposeNoMainService" xml:space="preserve">
+    <value>Compose file for challenge {0} contains no 'main' service.</value>
+  </data>
   <data name="ContainerManager_ContainerCreationFailedResponse" xml:space="preserve">
     <value>容器 {0} 創建失敗, 響應：{1}</value>
+  </data>
+  <data name="ContainerManager_ComposeCreationFailed" xml:space="preserve">
+    <value>Launching compose file for challenge {0} failed with exit code {1}: {2}</value>
+  </data>
+  <data name="ContainerManager_DockerCommandFailed" xml:space="preserve">
+    <value>Docker command failed with exit code {0}: {1}</value>
   </data>
   <data name="ContainerManager_ContainerCreationFailedStatus" xml:space="preserve">
     <value>容器 {0} 創建失敗, 狀態：{1}</value>
@@ -345,6 +363,9 @@
     <value>容器 {0} 創建後未獲取到埠暴露信息，創建失敗</value>
   </data>
   <data name="ContainerManager_DockerMode" xml:space="preserve">
+    <value>容器管理模式：Docker 單實例容器控制</value>
+  </data>
+  <data name="ContainerManager_DockerComposeMode" xml:space="preserve">
     <value>容器管理模式：Docker 單實例容器控制</value>
   </data>
   <data name="ContainerManager_K8sMode" xml:space="preserve">

--- a/src/GZCTF/Services/Container/ContainerServiceExtension.cs
+++ b/src/GZCTF/Services/Container/ContainerServiceExtension.cs
@@ -42,6 +42,8 @@ public static class ContainerServiceExtension
             {
                 ContainerProviderType.Docker => services
                     .AddSingleton<IContainerProvider<DockerClient, DockerMetadata>, DockerProvider>(),
+                ContainerProviderType.DockerCompose => services
+                    .AddSingleton<IContainerProvider<DockerClient, DockerMetadata>, DockerProvider>(),
                 ContainerProviderType.Kubernetes => services
                     .AddSingleton<IContainerProvider<Kubernetes, KubernetesMetadata>, KubernetesProvider>(),
                 _ => services
@@ -51,6 +53,7 @@ public static class ContainerServiceExtension
             => config.Type switch
             {
                 ContainerProviderType.Kubernetes => services.AddSingleton<IContainerManager, KubernetesManager>(),
+                ContainerProviderType.DockerCompose => services.AddSingleton<IContainerManager, DockerComposeManager>(),
                 _ => services.AddSingleton<IContainerManager, DockerManager>()
             };
     }

--- a/src/GZCTF/Services/Container/Manager/DockerComposeManager.cs
+++ b/src/GZCTF/Services/Container/Manager/DockerComposeManager.cs
@@ -1,0 +1,390 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Diagnostics;
+using Docker.DotNet;
+using GZCTF.Models.Internal;
+using GZCTF.Services.Container.Provider;
+using ContainerStatus = GZCTF.Utils.ContainerStatus;
+
+namespace GZCTF.Services.Container.Manager;
+
+public class DockerComposeManager : IContainerManager
+{
+    readonly DockerClient _client;
+    readonly ILogger<DockerComposeManager> _logger;
+    readonly DockerMetadata _meta;
+    readonly DockerManager _fallbackManager;
+
+    public DockerComposeManager(IContainerProvider<DockerClient, DockerMetadata> provider, ILogger<DockerComposeManager> logger, ILogger<DockerManager> fallbackLogger)
+    {
+        _logger = logger;
+        _meta = provider.GetMetadata();
+        _client = provider.GetProvider();
+        _fallbackManager = new DockerManager(provider, fallbackLogger);
+
+        logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_DockerComposeMode)], TaskStatus.Success, LogLevel.Debug);
+    }
+
+
+    public async Task DestroyContainerAsync(Models.Data.Container container, CancellationToken token = default)
+    {
+        if (!container.Image.Trim('\n', '\r').Contains('\n'))
+        {
+            await _fallbackManager.DestroyContainerAsync(container, token);
+            return;
+        }
+
+        try
+        {
+            using TempDir tempDir = new TempDir("gzdockertmp_");
+            using TempDir loginDir = new TempDir();
+
+            await RunCommand("docker",
+                ["compose", "--file", "-", "--project-name", container.ContainerId, "--progress", "plain", "down", "--remove-orphans", "--volumes"],
+                new Dictionary<string, string?> { { "DOCKER_HOST", _meta.Config.Uri }, { "DOCKER_CONFIG", loginDir.ToString() } },
+                tempDir.ToString(), container.Image, token);
+        }
+        catch (LaunchException le)
+        {
+            _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_ComposeDeletionFailedResponse), container.ContainerId, le.ExitCode, le.Message],
+                TaskStatus.Failed, LogLevel.Error);
+            return;
+        }
+        catch (Exception e)
+        {
+            _logger.LogErrorMessage(e, StaticLocalizer[nameof(Resources.Program.ContainerManager_ComposeDeletionFailed), container.ContainerId]);
+            return;
+        }
+
+        container.Status = ContainerStatus.Destroyed;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0037")]
+    private async Task GenerateComposeOverride(string filename, List<string> services, ContainerConfig config, CancellationToken token = default)
+    {
+        var compose = new
+        {
+            services = new Dictionary<string, object>(),
+            networks = new Dictionary<string, object>(),
+        };
+
+        var networks = new Dictionary<string, object?>();
+
+        if (!String.IsNullOrWhiteSpace(_meta.Config.ChallengeNetwork))
+        {
+            compose.networks[_meta.Config.ChallengeNetwork] = new
+            {
+                name = _meta.Config.ChallengeNetwork,
+                external = true,
+            };
+
+            networks[_meta.Config.ChallengeNetwork] = null;
+        }
+
+        var labels = new
+        {
+            TeamId = config.TeamId,
+            UserId = config.UserId.ToString(),
+            ChallengeId = config.ChallengeId.ToString()
+        };
+
+        var mainService = new Dictionary<string, object>
+        {
+            { "ports", new[] { $"0:{config.ExposedPort}" } },
+            { "labels", labels },
+            { "mem_limit", $"{config.MemoryLimit}M" },
+            { "cpus", config.CPUCount / 10.0 },
+            //// This only works if the backing storage is xfs+pquota, maybe try to query it somehow?
+            // { "storage_opt", new { size = $"{config.StorageLimit}M" } },
+        };
+
+        if (networks.Count != 0)
+            mainService["networks"] = networks;
+
+        compose.services.Add("main", mainService);
+
+        foreach (var service in services)
+        {
+            if (service == "main")
+                continue;
+
+            var serviceObj = new Dictionary<string, object>
+            {
+                { "labels", labels },
+                { "mem_limit", $"{config.MemoryLimit}M" },
+                { "cpus", config.CPUCount / 10.0 },
+                //// This only works if the backing storage is xfs+pquota, maybe try to query it somehow?
+                // { "storage_opt", new { size = $"{config.StorageLimit}M" } },
+            };
+
+            if (networks.Count != 0)
+                serviceObj["networks"] = networks;
+
+            compose.services.Add(service, serviceObj);
+        }
+
+        string json = JsonSerializer.Serialize(compose);
+        await File.WriteAllTextAsync(filename, json, token);
+    }
+
+    public async Task<Models.Data.Container?> CreateContainerAsync(ContainerConfig config, CancellationToken token = default)
+    {
+        // if the image is just a single line, assume it's a classic docker image and use the normal manager
+        if (!config.Image.Trim('\n', '\r').Contains('\n'))
+            return await _fallbackManager.CreateContainerAsync(config, token);
+
+        string name = $"{config.TeamId}_{config.ChallengeId}_{(config.Flag ?? Guid.NewGuid().ToString("N")).ToMD5String()[..16]}";
+        using TempDir tempDir = new TempDir("gzdockertmp_");
+        using TempDir loginDir = new TempDir();
+        var defaultEnv = new Dictionary<string, string?> { { "DOCKER_HOST", _meta.Config.Uri }, { "DOCKER_CONFIG", loginDir.ToString() } };
+
+        List<string> services;
+
+        try
+        {
+            services = await RunCommand("docker", ["compose", "--file", "-", "--project-name", name, "config", "--services"],
+                defaultEnv, tempDir.ToString(), config.Image, token);
+
+            if (!services.Contains("main"))
+            {
+                _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_ComposeNoMainService), config.ChallengeId], TaskStatus.Failed, LogLevel.Warning);
+                return null;
+            }
+
+            var images = await RunCommand("docker", ["compose", "--file", "-", "--project-name", name, "config", "--images"],
+                defaultEnv, tempDir.ToString(), config.Image, token);
+
+            foreach (var image in images)
+            {
+                var auth = _meta.AuthConfigs.GetForImage(image, out var registry);
+                if (auth is null)
+                    continue;
+
+                await RunCommand("docker", ["login", "--password-stdin", "--username", auth.Username, registry],
+                    defaultEnv, tempDir.ToString(), auth.Password, token);
+            }
+        }
+        catch (LaunchException le)
+        {
+            _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_DockerCommandFailed), le.ExitCode, le.Message],
+                TaskStatus.Failed, LogLevel.Error);
+            return null;
+        }
+
+        string preludeFile = Path.Combine(tempDir.Path.ToString(), "override.json");
+        await GenerateComposeOverride(preludeFile, services, config, token);
+
+        try
+        {
+            await RunCommand("docker",
+                ["compose", "--file", preludeFile, "--file", "-", "--project-name", name, "--progress", "plain", "up", "-d", "--wait", "--pull", "missing"],
+                new Dictionary<string, string?>
+                {
+                { "DOCKER_HOST", _meta.Config.Uri },
+                { "DOCKER_CONFIG", loginDir.ToString() },
+                { "CPU_COUNT", (config.CPUCount / 10.0).ToString() },
+                { "MEM_LIMIT", (config.MemoryLimit * 1024 * 1024).ToString() },
+                { "NET_MODE", _meta.Config.ChallengeNetwork ?? "default" },
+                { "GZCTF_TEAM_ID", config.TeamId },
+                { "GZCTF_FLAG", config.Flag },
+                },
+                tempDir.ToString(), config.Image, token);
+        }
+        catch (LaunchException le)
+        {
+            _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_ComposeCreationFailed), config.ChallengeId, le.ExitCode, le.Message],
+                TaskStatus.Failed, LogLevel.Warning);
+            return null;
+        }
+
+        Models.Data.Container container = new Models.Data.Container { ContainerId = name, Image = config.Image };
+        string mainId;
+
+        try
+        {
+            var mainIds = await RunCommand("docker", ["compose", "--file", "-", "--project-name", name, "ps", "-q", "main"],
+                defaultEnv, tempDir.ToString(), config.Image, token);
+            if (mainIds.Count != 1)
+            {
+                _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_ComposeUnexpectedIDs)],
+                    TaskStatus.Failed, LogLevel.Error);
+
+                await DestroyContainerAsync(container, token);
+                return null;
+            }
+
+            mainId = mainIds[0];
+        }
+        catch (LaunchException le)
+        {
+            _logger.SystemLog(StaticLocalizer[nameof(Resources.Program.ContainerManager_DockerCommandFailed), le.ExitCode, le.Message],
+                TaskStatus.Failed, LogLevel.Error);
+
+            await DestroyContainerAsync(container, token);
+            return null;
+        }
+
+        var info = await _client.Containers.InspectContainerAsync(mainId, token);
+
+        container.IP = info.NetworkSettings.Networks.FirstOrDefault().Value.IPAddress;
+        container.Port = config.ExposedPort;
+        container.IsProxy = !_meta.ExposePort;
+        container.StartedAt = DateTimeOffset.Parse(info.State.StartedAt);
+        container.ExpectStopAt = container.StartedAt + TimeSpan.FromHours(2);
+
+        container.Status = info.State.Dead || info.State.OOMKilled || info.State.Restarting
+            ? ContainerStatus.Destroyed
+            : info.State.Running
+                ? ContainerStatus.Running
+                : ContainerStatus.Pending;
+
+        if (container.Status != ContainerStatus.Running)
+        {
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.ContainerManager_ContainerInstanceCreationFailedWithError), "Compose Script", info.State.Error],
+                TaskStatus.Failed, LogLevel.Warning);
+
+            await DestroyContainerAsync(container, token);
+            return null;
+        }
+
+        if (!_meta.ExposePort)
+            return container;
+
+        var port = info.NetworkSettings.Ports
+            .FirstOrDefault(p =>
+                p.Key.StartsWith(config.ExposedPort.ToString() + "/") || p.Key == config.ExposedPort.ToString()
+            ).Value.First().HostPort;
+
+        if (int.TryParse(port, out var numPort))
+            container.PublicPort = numPort;
+        else
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.ContainerManager_PortParsingFailed), port],
+                TaskStatus.Failed,
+                LogLevel.Warning);
+
+        if (!string.IsNullOrEmpty(_meta.PublicEntry))
+            container.PublicIP = _meta.PublicEntry;
+
+        return container;
+    }
+
+    private async Task<List<string>> RunCommand(string command, string[] arguments, Dictionary<string, string?>? env = null, string workdir = "", string? input = null, CancellationToken token = default)
+    {
+        command = ResolvePath(command);
+
+        using var proc = new Process();
+        proc.StartInfo = new ProcessStartInfo
+        {
+            FileName = command,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            CreateNoWindow = true,
+            WorkingDirectory = workdir,
+        };
+
+        foreach (string arg in arguments)
+            proc.StartInfo.ArgumentList.Add(arg);
+
+        foreach (var pair in env ?? [])
+            if (pair.Value != null)
+                proc.StartInfo.Environment.Add(pair.Key, pair.Value);
+
+        proc.EnableRaisingEvents = true;
+
+        List<string> res = new List<string>();
+        DataReceivedEventHandler handler = (sender, data) => { if (data.Data != null) res.Add(data.Data); };
+        proc.OutputDataReceived += handler;
+        proc.ErrorDataReceived += handler;
+
+        try
+        {
+            proc.Start();
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            using (var writer = proc.StandardInput)
+                if (input != null)
+                    await writer.WriteAsync(input);
+
+            await proc.WaitForExitAsync(token);
+
+            if (proc.ExitCode != 0)
+                throw new LaunchException(proc.ExitCode, $"{command} {String.Join(' ', arguments)}{Environment.NewLine}{String.Join(Environment.NewLine, res)}");
+
+            return res;
+        }
+        finally
+        {
+            proc.OutputDataReceived -= handler;
+            proc.ErrorDataReceived -= handler;
+        }
+    }
+
+    private Dictionary<string, string> _resolvedCommands = [];
+
+    private string ResolvePath(string command)
+    {
+        if (_resolvedCommands.TryGetValue(command, out var res))
+            return res;
+
+        if (!Path.IsPathRooted(command) && !command.Contains(Path.DirectorySeparatorChar) && !command.Contains(Path.AltDirectorySeparatorChar) && !File.Exists(command))
+        {
+            string[] path = Environment.GetEnvironmentVariable("PATH")!.Split(Path.PathSeparator);
+            string[] exts = Environment.GetEnvironmentVariable("PATHEXT")?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
+
+            foreach (string dir in path)
+            {
+                string fullCommand = Path.Combine(dir, command);
+                if (File.Exists(fullCommand))
+                {
+                    _resolvedCommands.Add(command, fullCommand);
+                    return fullCommand;
+                }
+
+                foreach (string ext in exts)
+                {
+                    string fullCommandExt = fullCommand + ext;
+                    if (File.Exists(fullCommandExt))
+                    {
+                        _resolvedCommands.Add(command, fullCommandExt);
+                        return fullCommandExt;
+                    }
+                }
+            }
+        }
+
+        return command;
+    }
+
+    private class TempDir : IDisposable
+    {
+        public DirectoryInfo Path { get; private set; }
+        public override string ToString() => Path.FullName;
+
+        public TempDir(string? prefix = null)
+        {
+            Path = Directory.CreateTempSubdirectory(prefix);
+        }
+
+        public void Dispose()
+        {
+            if (Path.Exists)
+                Path.Delete(true);
+        }
+    }
+
+    private class LaunchException : Exception
+    {
+        public int ExitCode { get; private set; }
+
+        public LaunchException(int code, string message)
+            : base(message)
+        {
+            ExitCode = code;
+        }
+    }
+}

--- a/src/GZCTF/build.sh
+++ b/src/GZCTF/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+set -xe
+
+DOTNET=dotnet
+if command -v dotnet.exe 2>&1 >/dev/null && ! command -v dotnet 2>&1 >/dev/null; then
+	DOTNET=dotnet.exe
+fi
+
+$DOTNET build "GZCTF.csproj" -c Release -o build
+$DOTNET publish "GZCTF.csproj" -c Release -o publish/linux/amd64 -r linux-x64 --no-self-contained /p:PublishReadyToRun=true
+docker build -t gztime/gzctf:latest .


### PR DESCRIPTION
This new container manager is one part of the results of my bachelor's thesis on GZ::CTF.
CZ::CTF is being used at my university, and while using it, the desire to create more complex and involved challenges arose.
So as part of my thesis, I analyzed multiple potential ways to tackle that need and, in the end, decided to implement support for running entire Docker Compose projects in a challenge, rather than just a single image.

The most obvious immediate implication of this is that any administrator now has a lot more power, equivalent to root, on their hands, unless further measures are taken to restrict that power.
Thus, included in the PR is a sample compose file on how to run GZ::CTF with support for Docker Compose in a way that does not automatically make any admin root and also isolates them from the host's dockerd entirely by relying on rootless Docker-in-Docker.

A most simple example compose file looks like this:

```YAML
services:
  main:
    image: nginx:latest
```

Combined with the exposed port being set to 80, this will make a vanilla Nginx respond as the challenge target.
The service called “main” always has to exist and serves as entry point into the challenge.

This is achieved without any modifications to the database schema, simply by putting the compose YAML into the field that normally holds the image name (it accepts large multi-line text just fine).
While adding a sanity check that just assumes it's an image if it's just one single line.
In which case it is launched like normal. This way, an instance can be “upgraded” to Docker Compose without any breakage.

The general mode of operation is that internally a second compose file is generated, which contains the various settings like the exposed port (which is automatically added to the “main” service), limits, and labels, and applies them to all services in the compose file.
The user-provided compose file is then overlaid on top of that generated file, allowing it full flexibility to override whatever it likes.
Compose-Projects are isolated from one another by the normal logic that normally generates the container name, just that it now determines the project name, and Compose then takes care of bringing that project up and down cleanly.

To make admins actually able to enter a compose file, a tiny new API was added that exports the used container manager, and if it's DockerCompose, the frontend will show a multi-line Textarea in place of the usual image field.
In my tests this integrated fairly well into the existing UI.

I assume this will need some refactoring before being ready for merge, like extracting all the helpers that are currently just part of the Manager class.
But I wanted to gather general feedback first.

What is the correct way to deal with the localizations?
I have more or less just pre-filled all of them with the English version or other similar strings, but I doubt that's the correct approach?

(The second part of my thesis implemented an import/export function for challenges and games, which we seem to have developed independently in parallel. The approaches are similar yet different, so I'll have to see how to proceed with that part. If you want to take a look, all the thesis-related code is frozen in the “ba” branch: https://github.com/TimoRoth/GZCTF/tree/ba)