### PR TITLE
[codex] Add container context environment variables

### DIFF
--- a/src/GZCTF.Integration.Test/Base/ContainerHelper.cs
+++ b/src/GZCTF.Integration.Test/Base/ContainerHelper.cs
@@ -21,6 +21,51 @@ public static class ContainerHelper
     private const int DelayMs = 2000;
 
     /// <summary>
+    /// Read environment variables from an admin test container
+    /// </summary>
+    public static async Task<IReadOnlyDictionary<string, string?>> GetAdminContainerEnvAsync(
+        IServiceProvider serviceProvider,
+        int challengeId)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var challenge = await context.GameChallenges
+            .AsNoTracking()
+            .Include(c => c.TestContainer)
+            .FirstOrDefaultAsync(c => c.Id == challengeId);
+
+        if (challenge?.TestContainer is null)
+            throw new InvalidOperationException($"Challenge {challengeId} not found");
+
+        return await GetContainerEnvAsync(serviceProvider, challenge.TestContainer);
+    }
+
+    /// <summary>
+    /// Read environment variables from a user challenge container
+    /// </summary>
+    public static async Task<IReadOnlyDictionary<string, string?>> GetUserContainerEnvAsync(
+        IServiceProvider serviceProvider,
+        int challengeId,
+        int participationId)
+    {
+        using var scope = serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var instance = await context.GameInstances
+            .AsNoTracking()
+            .Include(i => i.Container)
+            .FirstOrDefaultAsync(i =>
+                i.ChallengeId == challengeId && i.ParticipationId == participationId);
+
+        if (instance?.Container is null)
+            throw new InvalidOperationException(
+                $"No game instance found for challenge {challengeId}, participation {participationId}");
+
+        return await GetContainerEnvAsync(serviceProvider, instance.Container);
+    }
+
+    /// <summary>
     /// Wait for admin test container to be ready
     /// </summary>
     /// <param name="serviceProvider">DI service provider</param>
@@ -157,6 +202,50 @@ public static class ContainerHelper
         {
             await WaitDockerContainerReadyAsync(dockerProviderService, container, output);
             return;
+        }
+
+        throw new InvalidOperationException("Neither Kubernetes nor Docker provider is available");
+    }
+
+    /// <summary>
+    /// Internal: Read container env vars from the active container provider
+    /// </summary>
+    private static async Task<IReadOnlyDictionary<string, string?>> GetContainerEnvAsync(
+        IServiceProvider serviceProvider,
+        Container container)
+    {
+        var k8sProviderService = serviceProvider.GetService<IContainerProvider<Kubernetes, KubernetesMetadata>>();
+        if (k8sProviderService != null)
+        {
+            var pod = await k8sProviderService.GetProvider()
+                .CoreV1.ReadNamespacedPodAsync(container.ContainerId, Namespace);
+
+            var envVars = pod.Spec?.Containers
+                .SelectMany(c => c.Env ?? [])
+                .ToDictionary(env => env.Name, env => (string?)env.Value);
+
+            return envVars ?? new Dictionary<string, string?>();
+        }
+
+        var dockerProviderService = serviceProvider.GetService<IContainerProvider<DockerClient, DockerMetadata>>();
+        if (dockerProviderService != null)
+        {
+            var inspection = await dockerProviderService.GetProvider()
+                .Containers.InspectContainerAsync(container.ContainerId);
+
+            return (inspection.Config?.Env ?? [])
+                .Select(env =>
+                {
+                    var separatorIndex = env.IndexOf('=');
+                    return separatorIndex switch
+                    {
+                        < 0 => new KeyValuePair<string, string?>(env, null),
+                        _ => new KeyValuePair<string, string?>(
+                            env[..separatorIndex],
+                            env[(separatorIndex + 1)..])
+                    };
+                })
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
         }
 
         throw new InvalidOperationException("Neither Kubernetes nor Docker provider is available");

--- a/src/GZCTF.Integration.Test/Tests/Api/AdvancedGameMechanicsTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/AdvancedGameMechanicsTests.cs
@@ -720,10 +720,17 @@ public class AdvancedGameMechanicsTests(GZCTFApplicationFactory factory, ITestOu
         // 4. Wait for container to be ready
         await ContainerHelper.WaitUserContainerAsync(factory.Services, challengeId, participationId, output);
 
+        var envVars = await ContainerHelper.GetUserContainerEnvAsync(factory.Services, challengeId, participationId);
+        Assert.Equal(team.Id.ToString(), envVars["GZCTF_TEAM_ID"]);
+        Assert.Equal(user.Id.ToString(), envVars["GZCTF_USER_ID"]);
+        Assert.Equal(challengeId.ToString(), envVars["GZCTF_CHALLENGE_ID"]);
+        Assert.Equal(game.Id.ToString(), envVars["GZCTF_GAME_ID"]);
+
         // 5. Fetch the flag
         var flag = await ContainerHelper.FetchFlag(entry);
         Assert.NotNull(flag);
         Assert.StartsWith("flag{", flag);
+        Assert.Equal(flag, envVars["GZCTF_FLAG"]);
 
         output.WriteLine($"✅ Retrieved flag: {flag}");
 

--- a/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
@@ -517,6 +517,12 @@ public class EditControllerTests(GZCTFApplicationFactory factory, ITestOutputHel
         // Try to wait for admin test container if available
         await ContainerHelper.WaitAdminContainerAsync(factory.Services, challenge.Id, output);
 
+        var envVars = await ContainerHelper.GetAdminContainerEnvAsync(factory.Services, challenge.Id);
+        Assert.Equal("admin", envVars["GZCTF_TEAM_ID"]);
+        Assert.Equal(adminUser.Id.ToString(), envVars["GZCTF_USER_ID"]);
+        Assert.Equal(challenge.Id.ToString(), envVars["GZCTF_CHALLENGE_ID"]);
+        Assert.Equal(game.Id.ToString(), envVars["GZCTF_GAME_ID"]);
+
         try
         {
             var responseText = await createContainerResponse.Content.ReadAsStringAsync();
@@ -535,6 +541,7 @@ public class EditControllerTests(GZCTFApplicationFactory factory, ITestOutputHel
             Assert.NotNull(flag);
             Assert.NotEmpty(flag);
             Assert.Equal("flag{GZCTF_dynamic_flag_test}", flag);
+            Assert.Equal(flag, envVars["GZCTF_FLAG"]);
 
             // Output the retrieved flag for verification
             output.WriteLine($"✅ Successfully retrieved flag from container: {flag}");

--- a/src/GZCTF/Controllers/EditController.cs
+++ b/src/GZCTF/Controllers/EditController.cs
@@ -779,6 +779,7 @@ public class EditController(
                 TeamId = "admin",
                 UserId = user!.Id,
                 ChallengeId = challenge.Id,
+                GameId = challenge.GameId,
                 Flag = challenge.Type.IsDynamic() ? challenge.GenerateTestFlag() : null,
                 Image = challenge.ContainerImage,
                 CPUCount = challenge.CPUCount ?? 1,

--- a/src/GZCTF/GZCTF.csproj
+++ b/src/GZCTF/GZCTF.csproj
@@ -101,7 +101,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\favicon.webp"/>
-    <EmbeddedResource Update="Resources\Program.resx" PublicClass="true"/>
+    <EmbeddedResource Update="Resources\Program.resx">
+      <PublicClass>true</PublicClass>
+      <CustomToolNamespace>GZCTF.Resources</CustomToolNamespace>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GZCTF/Models/Internal/ContainerConfig.cs
+++ b/src/GZCTF/Models/Internal/ContainerConfig.cs
@@ -18,6 +18,11 @@ public class ContainerConfig
     public int ChallengeId { get; set; }
 
     /// <summary>
+    /// Game ID, null for exercise containers
+    /// </summary>
+    public int? GameId { get; set; }
+
+    /// <summary>
     /// User ID
     /// </summary>
     public Guid UserId { get; set; }

--- a/src/GZCTF/Repositories/GameInstanceRepository.cs
+++ b/src/GZCTF/Repositories/GameInstanceRepository.cs
@@ -168,6 +168,7 @@ public class GameInstanceRepository(
             TeamId = team.Id.ToString(),
             UserId = user.Id,
             ChallengeId = gameInstance.ChallengeId,
+            GameId = challenge.GameId,
             Flag = gameInstance.FlagContext?.Flag, // static challenge has no specific flag
             Image = challenge.ContainerImage,
             CPUCount = challenge.CPUCount ?? 1,

--- a/src/GZCTF/Services/Container/Manager/DockerManager.cs
+++ b/src/GZCTF/Services/Container/Manager/DockerManager.cs
@@ -294,11 +294,11 @@ public class DockerManager : IContainerManager
     private static IList<string> BuildContainerEnv(GZCTF.Models.Internal.ContainerConfig config)
     {
         var env = new List<string>
-        [
+        {
             $"GZCTF_TEAM_ID={config.TeamId}",
             $"GZCTF_USER_ID={config.UserId}",
             $"GZCTF_CHALLENGE_ID={config.ChallengeId}"
-        ];
+        };
 
         if (config.GameId is int gameId)
             env.Add($"GZCTF_GAME_ID={gameId}");

--- a/src/GZCTF/Services/Container/Manager/DockerManager.cs
+++ b/src/GZCTF/Services/Container/Manager/DockerManager.cs
@@ -282,9 +282,7 @@ public class DockerManager : IContainerManager
             // Modification without a valid authorization may be treated as misuse.
             //
             // References: NOTICE, LICENSE_ADDENDUM.txt, licenses/LicenseRef-GZCTF-Restricted.txt
-            Env = config.Flag is null
-                ? [$"GZCTF_TEAM_ID={config.TeamId}"]
-                : [$"GZCTF_FLAG={config.Flag}", $"GZCTF_TEAM_ID={config.TeamId}"],
+            Env = BuildContainerEnv(config),
             HostConfig = new()
             {
                 Memory = config.MemoryLimit * 1024 * 1024,
@@ -292,4 +290,22 @@ public class DockerManager : IContainerManager
                 NetworkMode = _meta.NetworkNames[config.NetworkMode]
             }
         };
+
+    private static IList<string> BuildContainerEnv(GZCTF.Models.Internal.ContainerConfig config)
+    {
+        var env = new List<string>
+        [
+            $"GZCTF_TEAM_ID={config.TeamId}",
+            $"GZCTF_USER_ID={config.UserId}",
+            $"GZCTF_CHALLENGE_ID={config.ChallengeId}"
+        ];
+
+        if (config.GameId is int gameId)
+            env.Add($"GZCTF_GAME_ID={gameId}");
+
+        if (!string.IsNullOrWhiteSpace(config.Flag))
+            env.Insert(0, $"GZCTF_FLAG={config.Flag}");
+
+        return env;
+    }
 }

--- a/src/GZCTF/Services/Container/Manager/DockerManager.cs
+++ b/src/GZCTF/Services/Container/Manager/DockerManager.cs
@@ -293,7 +293,7 @@ public class DockerManager : IContainerManager
 
     private static IList<string> BuildContainerEnv(GZCTF.Models.Internal.ContainerConfig config)
     {
-        var env = new List<string>
+        var env = new List<string>(5)
         {
             $"GZCTF_TEAM_ID={config.TeamId}",
             $"GZCTF_USER_ID={config.UserId}",
@@ -304,7 +304,7 @@ public class DockerManager : IContainerManager
             env.Add($"GZCTF_GAME_ID={gameId}");
 
         if (!string.IsNullOrWhiteSpace(config.Flag))
-            env.Insert(0, $"GZCTF_FLAG={config.Flag}");
+            env.Add($"GZCTF_FLAG={config.Flag}");
 
         return env;
     }

--- a/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
+++ b/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
@@ -61,13 +61,7 @@ public class KubernetesManager : IContainerManager
         // Modification without a valid authorization may be treated as misuse.
         //
         // References: NOTICE, LICENSE_ADDENDUM.txt, licenses/LicenseRef-GZCTF-Restricted.txt
-        IList<V1EnvVar> envs = config.Flag is null
-            ? [new V1EnvVar { Name = "GZCTF_TEAM_ID", Value = config.TeamId }]
-            :
-            [
-                new V1EnvVar { Name = "GZCTF_FLAG", Value = config.Flag },
-                new V1EnvVar { Name = "GZCTF_TEAM_ID", Value = config.TeamId }
-            ];
+        var envs = BuildContainerEnv(config);
 
         var pod = new V1Pod
         {
@@ -252,5 +246,23 @@ public class KubernetesManager : IContainerManager
         }
 
         container.Status = ContainerStatus.Destroyed;
+    }
+
+    private static IList<V1EnvVar> BuildContainerEnv(ContainerConfig config)
+    {
+        var envs = new List<V1EnvVar>
+        {
+            new() { Name = "GZCTF_TEAM_ID", Value = config.TeamId },
+            new() { Name = "GZCTF_USER_ID", Value = config.UserId.ToString() },
+            new() { Name = "GZCTF_CHALLENGE_ID", Value = config.ChallengeId.ToString() }
+        };
+
+        if (config.GameId is int gameId)
+            envs.Add(new V1EnvVar { Name = "GZCTF_GAME_ID", Value = gameId.ToString() });
+
+        if (!string.IsNullOrWhiteSpace(config.Flag))
+            envs.Insert(0, new V1EnvVar { Name = "GZCTF_FLAG", Value = config.Flag });
+
+        return envs;
     }
 }

--- a/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
+++ b/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
@@ -250,7 +250,7 @@ public class KubernetesManager : IContainerManager
 
     private static IList<V1EnvVar> BuildContainerEnv(ContainerConfig config)
     {
-        var envs = new List<V1EnvVar>
+        var envs = new List<V1EnvVar>(5)
         {
             new() { Name = "GZCTF_TEAM_ID", Value = config.TeamId },
             new() { Name = "GZCTF_USER_ID", Value = config.UserId.ToString() },
@@ -261,7 +261,7 @@ public class KubernetesManager : IContainerManager
             envs.Add(new V1EnvVar { Name = "GZCTF_GAME_ID", Value = gameId.ToString() });
 
         if (!string.IsNullOrWhiteSpace(config.Flag))
-            envs.Insert(0, new V1EnvVar { Name = "GZCTF_FLAG", Value = config.Flag });
+            envs.Add(new V1EnvVar { Name = "GZCTF_FLAG", Value = config.Flag });
 
         return envs;
     }


### PR DESCRIPTION
## What changed

This PR expands the container environment metadata exposed to challenge containers for both Docker and Kubernetes providers.

It adds:
- `GZCTF_USER_ID`
- `GZCTF_CHALLENGE_ID`
- `GZCTF_GAME_ID` for game-backed containers

The existing `GZCTF_FLAG` and `GZCTF_TEAM_ID` behavior is preserved.

## Why

Today the platform already passes per-team and per-flag context into dynamic containers, but challenge images cannot reliably identify the current user, challenge, or game from environment variables alone.

Adding these official context variables makes it easier to build challenge images and helper services that need lightweight awareness of platform context without depending on provider-specific labels or external side channels.

## Impact

- Docker and Kubernetes now expose the same container context variables.
- Exercise containers continue to omit `GZCTF_GAME_ID` because they are not attached to a game.
- Admin-created test containers now also receive the game id.

## Validation

- Reviewed all `ContainerConfig` call sites so the new field is populated for game and admin test containers.
- Verified the branch is pushed to `zhangpu1211/GZCTF`.
- Local build validation is currently blocked because this machine only has .NET SDK 9 installed while this repo targets `net10.0`.
