### PR TITLE
[codex] Add configurable container pre-stop commands

### DIFF
--- a/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
@@ -212,6 +212,75 @@ public class EditControllerTests(GZCTFApplicationFactory factory, ITestOutputHel
     }
 
     /// <summary>
+    /// Test UpdateGameChallenge persists pre-stop command configuration
+    /// </summary>
+    [Fact]
+    public async Task UpdateGameChallenge_ShouldPersistPreStopCommand()
+    {
+        var adminPassword = "Admin@Pass123";
+        var adminUser = await TestDataSeeder.CreateUserAsync(factory.Services,
+            TestDataSeeder.RandomName(), adminPassword, role: Role.Admin);
+
+        var game = await TestDataSeeder.CreateGameAsync(factory.Services, "Pre-stop Command Test");
+        var challengeId = 0;
+
+        await using (var scope = factory.Services.CreateAsyncScope())
+        {
+            var gameRepository = scope.ServiceProvider.GetRequiredService<IGameRepository>();
+            var challengeRepository = scope.ServiceProvider.GetRequiredService<IGameChallengeRepository>();
+
+            var gameEntity = await gameRepository.GetGameById(game.Id)
+                             ?? throw new InvalidOperationException($"Game {game.Id} not found");
+
+            var challengeEntity = new GameChallenge
+            {
+                Title = "Hook Challenge",
+                Content = "Container challenge content",
+                Category = ChallengeCategory.Misc,
+                Type = ChallengeType.DynamicContainer,
+                Hints = [],
+                IsEnabled = true,
+                SubmissionLimit = 0,
+                OriginalScore = 500,
+                MinScoreRate = 0.8,
+                Difficulty = 5,
+                ContainerImage = "ghcr.io/gzctf/challenge-base/echo:latest",
+                ExposePort = 80,
+                CPUCount = 1,
+                MemoryLimit = 64,
+                StorageLimit = 256,
+                Game = gameEntity,
+                GameId = gameEntity.Id
+            };
+
+            await challengeRepository.CreateChallenge(gameEntity, challengeEntity);
+            challengeId = challengeEntity.Id;
+        }
+
+        using var adminClient = factory.CreateClient();
+
+        var loginResponse = await adminClient.PostAsJsonAsync("/api/Account/LogIn",
+            new LoginModel { UserName = adminUser.UserName, Password = adminPassword });
+        loginResponse.EnsureSuccessStatusCode();
+
+        var updateResponse = await adminClient.PutAsJsonAsync($"/api/Edit/Games/{game.Id}/Challenges/{challengeId}",
+            new ChallengeUpdateModel { PreStopCommand = "  /about_to_destroy  " });
+        updateResponse.EnsureSuccessStatusCode();
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<ChallengeEditDetailModel>();
+
+        Assert.NotNull(updated);
+        Assert.Equal("/about_to_destroy", updated.PreStopCommand);
+
+        var getResponse = await adminClient.GetAsync($"/api/Edit/Games/{game.Id}/Challenges/{challengeId}");
+        getResponse.EnsureSuccessStatusCode();
+        var detail = await getResponse.Content.ReadFromJsonAsync<ChallengeEditDetailModel>();
+
+        Assert.NotNull(detail);
+        Assert.Equal("/about_to_destroy", detail.PreStopCommand);
+    }
+
+    /// <summary>
     /// Test DeleteDivision works correctly
     /// </summary>
     [Fact]

--- a/src/GZCTF.Test/UnitTests/Transfer/TransferChallengeTests.cs
+++ b/src/GZCTF.Test/UnitTests/Transfer/TransferChallengeTests.cs
@@ -76,6 +76,7 @@ public class TransferChallengeTests
             CPUCount = 2,
             StorageLimit = 512,
             ExposePort = 9999,
+            PreStopCommand = "/about_to_destroy",
             FileName = "exploit",
             NetworkMode = NetworkMode.Custom,
             Flags = []
@@ -95,6 +96,7 @@ public class TransferChallengeTests
         Assert.Equal(2, transfer.Container.CpuCount);
         Assert.Equal(512, transfer.Container.StorageLimit);
         Assert.Equal(9999, transfer.Container.ExposePort);
+        Assert.Equal("/about_to_destroy", transfer.Container.PreStopCommand);
         Assert.Equal("exploit", transfer.Container.FileName);
         Assert.Equal(NetworkMode.Custom, transfer.Container.NetworkMode);
     }
@@ -116,7 +118,17 @@ public class TransferChallengeTests
             EnableTrafficCapture = false,
             Static = [new() { Value = "flag{crypto_master}" }]
         },
-        Hints = ["RSA", "Small e"]
+        Hints = ["RSA", "Small e"],
+        Container = new ContainerSection
+        {
+            Image = "crypto/toolkit:latest",
+            MemoryLimit = 64,
+            CpuCount = 1,
+            StorageLimit = 128,
+            ExposePort = 1337,
+            PreStopCommand = "/cleanup",
+            NetworkMode = NetworkMode.Isolated
+        }
     };
 
     [Fact]
@@ -137,6 +149,7 @@ public class TransferChallengeTests
         Assert.Equal(10, challenge.SubmissionLimit);
         Assert.True(challenge.DisableBloodBonus);
         Assert.Equal(2, challenge.Hints!.Count);
+        Assert.Equal("/cleanup", challenge.PreStopCommand);
     }
 
     [Fact]

--- a/src/GZCTF/ClientApp/src/Api.ts
+++ b/src/GZCTF/ClientApp/src/Api.ts
@@ -1167,6 +1167,8 @@ export interface ChallengeEditDetailModel {
    * @format int32
    */
   exposePort?: number | null;
+  /** Optional command path executed inside the container before it is destroyed */
+  preStopCommand?: string | null;
   /** Container network mode */
   networkMode?: NetworkMode | null;
   /** Whether to record traffic */
@@ -1348,6 +1350,8 @@ export interface ChallengeUpdateModel {
    * @format int32
    */
   exposePort?: number | null;
+  /** Optional command path executed inside the container before it is destroyed */
+  preStopCommand?: string | null;
   /** Container network mode */
   networkMode?: NetworkMode | null;
   /** Is traffic capture enabled (disabled by default) */

--- a/src/GZCTF/ClientApp/src/locales/en-US/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/en-US/admin.json
@@ -164,6 +164,10 @@
             "open": "Open"
           }
         },
+        "pre_stop_command": {
+          "description": "Optional executable path invoked inside the container before it is destroyed. It runs directly without a shell.",
+          "label": "Pre-stop Command"
+        },
         "score": "Score",
         "service_port": {
           "description": "Port of container services",

--- a/src/GZCTF/ClientApp/src/locales/zh-CN/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/zh-CN/admin.json
@@ -164,6 +164,10 @@
             "open": "开放"
           }
         },
+        "pre_stop_command": {
+          "description": "容器销毁前在容器内执行的可选命令路径，直接执行，不经过 shell。",
+          "label": "销毁前命令"
+        },
         "score": "题目分值",
         "service_port": {
           "description": "容器内服务的端口号",

--- a/src/GZCTF/ClientApp/src/locales/zh-TW/admin.json
+++ b/src/GZCTF/ClientApp/src/locales/zh-TW/admin.json
@@ -164,6 +164,10 @@
             "open": "開放"
           }
         },
+        "pre_stop_command": {
+          "description": "容器銷毀前在容器內執行的可選命令路徑，會直接執行，不經過 shell。",
+          "label": "銷毀前命令"
+        },
         "score": "題目分值",
         "service_port": {
           "description": "容器內服務的埠號",

--- a/src/GZCTF/ClientApp/src/pages/admin/games/[id]/challenges/[chalId]/Index.tsx
+++ b/src/GZCTF/ClientApp/src/pages/admin/games/[id]/challenges/[chalId]/Index.tsx
@@ -515,6 +515,16 @@ const GameChallengeEdit: FC = () => {
                 }}
               />
             </Grid.Col>
+            <Grid.Col span={8}>
+              <TextInput
+                label={t('admin.content.games.challenges.pre_stop_command.label')}
+                description={t('admin.content.games.challenges.pre_stop_command.description')}
+                disabled={disabled}
+                value={challengeInfo.preStopCommand ?? ''}
+                placeholder="/about_to_destroy"
+                onChange={(e) => setChallengeInfo({ ...challengeInfo, preStopCommand: e.target.value })}
+              />
+            </Grid.Col>
             <Grid.Col span={2}>
               <Select
                 required

--- a/src/GZCTF/Controllers/EditController.cs
+++ b/src/GZCTF/Controllers/EditController.cs
@@ -785,6 +785,7 @@ public class EditController(
                 MemoryLimit = challenge.MemoryLimit ?? 64,
                 StorageLimit = challenge.StorageLimit ?? 256,
                 NetworkMode = challenge.NetworkMode ?? NetworkMode.Open,
+                PreStopCommand = challenge.PreStopCommand,
                 ExposedPort = challenge.ExposePort.Value,
             }, token);
 

--- a/src/GZCTF/GZCTF.csproj
+++ b/src/GZCTF/GZCTF.csproj
@@ -101,7 +101,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\favicon.webp"/>
-    <EmbeddedResource Update="Resources\Program.resx" PublicClass="true"/>
+    <EmbeddedResource Update="Resources\Program.resx">
+      <PublicClass>true</PublicClass>
+      <CustomToolNamespace>GZCTF.Resources</CustomToolNamespace>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GZCTF/Migrations/20260418143000_AddPreStopCommand.cs
+++ b/src/GZCTF/Migrations/20260418143000_AddPreStopCommand.cs
@@ -1,0 +1,55 @@
+using GZCTF.Models;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GZCTF.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(AppDbContext))]
+    [Migration("20260418143000_AddPreStopCommand")]
+    public partial class AddPreStopCommand : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PreStopCommand",
+                table: "GameChallenges",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreStopCommand",
+                table: "ExerciseChallenges",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreStopCommand",
+                table: "Containers",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreStopCommand",
+                table: "GameChallenges");
+
+            migrationBuilder.DropColumn(
+                name: "PreStopCommand",
+                table: "ExerciseChallenges");
+
+            migrationBuilder.DropColumn(
+                name: "PreStopCommand",
+                table: "Containers");
+        }
+    }
+}

--- a/src/GZCTF/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/GZCTF/Migrations/AppDbContextModelSnapshot.cs
@@ -170,6 +170,10 @@ namespace GZCTF.Migrations
                     b.Property<int?>("PublicPort")
                         .HasColumnType("integer");
 
+                    b.Property<string>("PreStopCommand")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
+
                     b.Property<DateTimeOffset>("StartedAt")
                         .HasColumnType("timestamp with time zone");
 
@@ -283,6 +287,10 @@ namespace GZCTF.Migrations
                     b.Property<string>("FlagTemplate")
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
+
+                    b.Property<string>("PreStopCommand")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("Hints")
                         .HasColumnType("text");
@@ -574,6 +582,10 @@ namespace GZCTF.Migrations
                     b.Property<string>("FlagTemplate")
                         .HasMaxLength(120)
                         .HasColumnType("character varying(120)");
+
+                    b.Property<string>("PreStopCommand")
+                        .HasMaxLength(256)
+                        .HasColumnType("character varying(256)");
 
                     b.Property<int>("GameId")
                         .HasColumnType("integer");

--- a/src/GZCTF/Models/Data/Challenge.cs
+++ b/src/GZCTF/Models/Data/Challenge.cs
@@ -91,6 +91,12 @@ public class Challenge
     public NetworkMode? NetworkMode { get; set; } = Utils.NetworkMode.Open;
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    [MaxLength(256)]
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Download file name, used only for dynamic attachment unified file name
     /// </summary>
     public string? FileName { get; set; } = "attachment";

--- a/src/GZCTF/Models/Data/Container.cs
+++ b/src/GZCTF/Models/Data/Container.cs
@@ -87,6 +87,12 @@ public class Container
     public int? PublicPort { get; set; }
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    [MaxLength(256)]
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Container instance access method
     /// </summary>
     [NotMapped]

--- a/src/GZCTF/Models/Data/GameChallenge.cs
+++ b/src/GZCTF/Models/Data/GameChallenge.cs
@@ -87,6 +87,9 @@ public class GameChallenge : Challenge
         if (model.FlagTemplate is { } template)
             FlagTemplate = string.IsNullOrWhiteSpace(template) ? null : template;
 
+        if (model.PreStopCommand is { } preStopCommand)
+            PreStopCommand = string.IsNullOrWhiteSpace(preStopCommand) ? null : preStopCommand.Trim();
+
         // Container only
         EnableTrafficCapture = Type.IsContainer() && (model.EnableTrafficCapture ?? EnableTrafficCapture);
     }

--- a/src/GZCTF/Models/Internal/ContainerConfig.cs
+++ b/src/GZCTF/Models/Internal/ContainerConfig.cs
@@ -33,6 +33,11 @@ public class ContainerConfig
     public string? Flag { get; set; } = string.Empty;
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Whether to record traffic
     /// </summary>
     public bool EnableTrafficCapture { get; set; }

--- a/src/GZCTF/Models/Request/Edit/ChallengeEditDetailModel.cs
+++ b/src/GZCTF/Models/Request/Edit/ChallengeEditDetailModel.cs
@@ -116,6 +116,11 @@ public class ChallengeEditDetailModel
     public NetworkMode? NetworkMode { get; set; }
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Whether to record traffic
     /// </summary>
     public bool? EnableTrafficCapture { get; set; } = false;
@@ -172,6 +177,7 @@ public class ChallengeEditDetailModel
             StorageLimit = chal.StorageLimit,
             ExposePort = chal.ExposePort,
             NetworkMode = chal.NetworkMode,
+            PreStopCommand = chal.PreStopCommand,
             EnableTrafficCapture = chal.EnableTrafficCapture,
             DisableBloodBonus = chal.DisableBloodBonus,
             OriginalScore = chal.OriginalScore,

--- a/src/GZCTF/Models/Request/Edit/ChallengeUpdateModel.cs
+++ b/src/GZCTF/Models/Request/Edit/ChallengeUpdateModel.cs
@@ -96,6 +96,12 @@ public class ChallengeUpdateModel
     public NetworkMode? NetworkMode { get; set; }
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    [MaxLength(256)]
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Is traffic capture enabled (disabled by default)
     /// </summary>
     public bool? EnableTrafficCapture { get; set; }

--- a/src/GZCTF/Models/Transfer/TransferChallenge.cs
+++ b/src/GZCTF/Models/Transfer/TransferChallenge.cs
@@ -267,6 +267,12 @@ public class ContainerSection
     public int ExposePort { get; set; } = 80;
 
     /// <summary>
+    /// Optional command path executed inside the container before it is destroyed
+    /// </summary>
+    [MaxLength(256, ErrorMessage = "Pre-stop command is too long")]
+    public string? PreStopCommand { get; set; }
+
+    /// <summary>
     /// Container network mode
     /// </summary>
     public NetworkMode? NetworkMode { get; set; } = Utils.NetworkMode.Open;

--- a/src/GZCTF/Models/Transfer/TransferExtensions.cs
+++ b/src/GZCTF/Models/Transfer/TransferExtensions.cs
@@ -118,6 +118,7 @@ public static class TransferExtensions
                     CpuCount = challenge.CPUCount ?? 1,
                     StorageLimit = challenge.StorageLimit ?? 256,
                     ExposePort = challenge.ExposePort ?? 80,
+                    PreStopCommand = challenge.PreStopCommand,
                     FileName = challenge.FileName,
                     NetworkMode = challenge.NetworkMode ?? NetworkMode.Open
                 };
@@ -275,6 +276,7 @@ public static class TransferExtensions
             challenge.CPUCount = transfer.Container.CpuCount;
             challenge.StorageLimit = transfer.Container.StorageLimit;
             challenge.ExposePort = transfer.Container.ExposePort;
+            challenge.PreStopCommand = transfer.Container.PreStopCommand;
             challenge.FileName = transfer.Container.FileName;
             challenge.NetworkMode = transfer.Container.NetworkMode;
 

--- a/src/GZCTF/Repositories/ExerciseInstanceRepository.cs
+++ b/src/GZCTF/Repositories/ExerciseInstanceRepository.cs
@@ -164,6 +164,7 @@ public class ExerciseInstanceRepository(
             MemoryLimit = instance.Exercise.MemoryLimit ?? 64,
             StorageLimit = instance.Exercise.StorageLimit ?? 256,
             NetworkMode = instance.Exercise.NetworkMode ?? NetworkMode.Open,
+            PreStopCommand = instance.Exercise.PreStopCommand,
             EnableTrafficCapture = false,
             ExposedPort = instance.Exercise.ExposePort.Value
         }, token);

--- a/src/GZCTF/Repositories/GameInstanceRepository.cs
+++ b/src/GZCTF/Repositories/GameInstanceRepository.cs
@@ -174,6 +174,7 @@ public class GameInstanceRepository(
             MemoryLimit = challenge.MemoryLimit ?? 64,
             StorageLimit = challenge.StorageLimit ?? 256,
             NetworkMode = challenge.NetworkMode ?? NetworkMode.Open,
+            PreStopCommand = challenge.PreStopCommand,
             EnableTrafficCapture = challenge.EnableTrafficCapture && game.IsActive,
             ExposedPort = challenge.ExposePort ??
                           throw new ArgumentException(

--- a/src/GZCTF/Services/Container/Manager/DockerManager.cs
+++ b/src/GZCTF/Services/Container/Manager/DockerManager.cs
@@ -13,6 +13,7 @@ namespace GZCTF.Services.Container.Manager;
 
 public class DockerManager : IContainerManager
 {
+    private static readonly TimeSpan PreStopTimeout = TimeSpan.FromSeconds(5);
     private readonly DockerClient _client;
     private readonly ILogger<DockerManager> _logger;
     private readonly DockerMetadata _meta;
@@ -30,6 +31,8 @@ public class DockerManager : IContainerManager
 
     public async Task DestroyContainerAsync(Models.Data.Container container, CancellationToken token = default)
     {
+        await TryRunPreStopCommandAsync(container, token);
+
         try
         {
             await _client.Containers.RemoveContainerAsync(container.ContainerId,
@@ -169,7 +172,12 @@ public class DockerManager : IContainerManager
             return null;
         }
 
-        var container = new Models.Data.Container { ContainerId = containerRes.ID, Image = config.Image };
+        var container = new Models.Data.Container
+        {
+            ContainerId = containerRes.ID,
+            Image = config.Image,
+            PreStopCommand = NormalizePreStopCommand(config.PreStopCommand)
+        };
 
         retry = 0;
 
@@ -292,4 +300,52 @@ public class DockerManager : IContainerManager
                 NetworkMode = _meta.NetworkNames[config.NetworkMode]
             }
         };
+
+    private async Task TryRunPreStopCommandAsync(Models.Data.Container container, CancellationToken token)
+    {
+        var command = NormalizePreStopCommand(container.PreStopCommand);
+
+        if (command is null)
+            return;
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(token);
+        timeout.CancelAfter(PreStopTimeout);
+
+        try
+        {
+            var exec = await _client.Exec.CreateContainerExecAsync(container.ContainerId,
+                new ContainerExecCreateParameters
+                {
+                    AttachStdout = true,
+                    AttachStderr = true,
+                    TTY = false,
+                    Cmd = [command]
+                }, timeout.Token);
+
+            using var stream = await _client.Exec.StartContainerExecAsync(exec.ID,
+                new ContainerExecStartParameters { Detach = false, TTY = false }, timeout.Token);
+            await stream.ReadOutputToEndAsync(timeout.Token);
+
+            var inspect = await _client.Exec.InspectContainerExecAsync(exec.ID, timeout.Token);
+
+            if (inspect.ExitCode != 0)
+            {
+                _logger.LogWarning("Container pre-stop command {Command} for {ContainerId} exited with code {ExitCode}",
+                    command, container.ContainerId, inspect.ExitCode);
+            }
+        }
+        catch (OperationCanceledException) when (!token.IsCancellationRequested)
+        {
+            _logger.LogWarning("Container pre-stop command {Command} for {ContainerId} timed out after {Timeout}s",
+                command, container.ContainerId, PreStopTimeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Container pre-stop command {Command} for {ContainerId} failed",
+                command, container.ContainerId);
+        }
+    }
+
+    private static string? NormalizePreStopCommand(string? command) =>
+        string.IsNullOrWhiteSpace(command) ? null : command.Trim();
 }

--- a/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
+++ b/src/GZCTF/Services/Container/Manager/KubernetesManager.cs
@@ -14,6 +14,7 @@ namespace GZCTF.Services.Container.Manager;
 
 public class KubernetesManager : IContainerManager
 {
+    private static readonly TimeSpan PreStopTimeout = TimeSpan.FromSeconds(5);
     private readonly Kubernetes _client;
     private readonly ILogger<KubernetesManager> _logger;
     private readonly KubernetesMetadata _meta;
@@ -208,6 +209,7 @@ public class KubernetesManager : IContainerManager
         {
             ContainerId = name,
             Image = config.Image,
+            PreStopCommand = NormalizePreStopCommand(config.PreStopCommand),
             Port = config.ExposedPort,
             IP = service.Spec.ClusterIP,
             IsProxy = !_meta.ExposePort,
@@ -226,6 +228,8 @@ public class KubernetesManager : IContainerManager
 
     public async Task DestroyContainerAsync(Models.Data.Container container, CancellationToken token = default)
     {
+        await TryRunPreStopCommandAsync(container, token);
+
         try
         {
             await _client.CoreV1.DeleteNamespacedServiceAsync(container.ContainerId, _meta.Config.Namespace,
@@ -253,4 +257,46 @@ public class KubernetesManager : IContainerManager
 
         container.Status = ContainerStatus.Destroyed;
     }
+
+    private async Task TryRunPreStopCommandAsync(Models.Data.Container container, CancellationToken token)
+    {
+        var command = NormalizePreStopCommand(container.PreStopCommand);
+
+        if (command is null)
+            return;
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(token);
+        timeout.CancelAfter(PreStopTimeout);
+
+        try
+        {
+            var exitCode = await _client.NamespacedPodExecAsync(
+                container.ContainerId,
+                _meta.Config.Namespace,
+                container.ContainerId,
+                [command],
+                false,
+                (_, _, _) => Task.CompletedTask,
+                timeout.Token);
+
+            if (exitCode != 0)
+            {
+                _logger.LogWarning("Container pre-stop command {Command} for {ContainerId} exited with code {ExitCode}",
+                    command, container.ContainerId, exitCode);
+            }
+        }
+        catch (OperationCanceledException) when (!token.IsCancellationRequested)
+        {
+            _logger.LogWarning("Container pre-stop command {Command} for {ContainerId} timed out after {Timeout}s",
+                command, container.ContainerId, PreStopTimeout.TotalSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Container pre-stop command {Command} for {ContainerId} failed",
+                command, container.ContainerId);
+        }
+    }
+
+    private static string? NormalizePreStopCommand(string? command) =>
+        string.IsNullOrWhiteSpace(command) ? null : command.Trim();
 }

--- a/src/GZCTF/Services/Transfer/GameImportService.cs
+++ b/src/GZCTF/Services/Transfer/GameImportService.cs
@@ -410,6 +410,7 @@ public class GameImportService(
             CPUCount = transferChallenge.Container?.CpuCount,
             StorageLimit = transferChallenge.Container?.StorageLimit,
             NetworkMode = transferChallenge.Container?.NetworkMode,
+            PreStopCommand = transferChallenge.Container?.PreStopCommand,
 
             // File settings
             FileName = transferChallenge.Container?.FileName,


### PR DESCRIPTION
## What changed

This PR adds an optional `PreStopCommand` for container-based challenges.

The command is stored at the challenge level, copied into the created container record, and executed as a best-effort hook right before the platform destroys the container.

It includes:
- persisted `PreStopCommand` support for game and exercise challenges
- propagation through container creation for admin test containers, game instances, and exercise instances
- best-effort execution in both Docker and Kubernetes container managers
- transfer/import support
- admin challenge edit UI support
- unit and integration test coverage for persistence and transfer mapping

## Why

A fork (`mygzctf`) uses a fixed `/about_to_destroy` hook before removing containers. That idea is valuable, but the hardcoded path is too specific for upstream.

This PR generalizes it into a configurable, optional platform capability:
- challenge authors can opt in only when needed
- the command is executed directly without going through a shell
- failures are logged but do not block container deletion
- a short timeout keeps cleanup best-effort instead of making deletion hang indefinitely

## Behavior

- If `PreStopCommand` is empty, container deletion behavior is unchanged.
- If `PreStopCommand` is configured, the platform tries to execute it inside the container before deletion.
- Docker and Kubernetes providers both use the same configuration field.
- The command is stored on the container instance so destruction does not depend on reloading the originating challenge.

## Validation

Local validation completed with .NET 10:
- `dotnet build src/GZCTF/GZCTF.csproj -c Release --no-restore`
- `dotnet test src/GZCTF.Test/GZCTF.Test.csproj -c Release --no-restore --filter FullyQualifiedName~TransferChallengeTests`
- `dotnet test src/GZCTF.Integration.Test/GZCTF.Integration.Test.csproj -c Release --no-restore --filter FullyQualifiedName~UpdateGameChallenge_ShouldPersistPreStopCommand`
- `pnpm build` in `src/GZCTF/ClientApp`

## Note

This branch also includes the minimal `Program.resx` namespace fix in `GZCTF.csproj`, because the current `develop` branch still hits a resource-generation conflict locally without it. The same fix was already needed on the previous PR to make build and integration testing work.
