### PR TITLE
feat(capture): shared per-container traffic recorder

### DIFF
--- a/src/GZCTF.Integration.Test/Base/ContainerHelper.cs
+++ b/src/GZCTF.Integration.Test/Base/ContainerHelper.cs
@@ -1,9 +1,11 @@
 using System.Net.Sockets;
+using System.Net.WebSockets;
 using Docker.DotNet;
 using GZCTF.Models;
 using GZCTF.Models.Data;
 using GZCTF.Services.Container.Provider;
 using k8s;
+using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
@@ -132,28 +134,44 @@ public static class ContainerHelper
     }
 
     /// <summary>
-    /// Fetch flag from container
+    /// Fetch flag from container, auto-detecting the access method based on entry format.
     /// NOTE: use `ghcr.io/gzctf/challenge-base/echo:latest`
     /// </summary>
-    /// <param name="entry"></param>
-    /// <returns></returns>
-    public static async Task<string?> FetchFlag(string entry)
+    /// <param name="entry">Container entry: a GUID for PlatformProxy, or "IP:Port" for direct TCP</param>
+    /// <param name="factory">
+    /// The WebApplicationFactory, required when entry is a GUID (PlatformProxy mode)
+    /// to create a WebSocket connection through the test server.
+    /// </param>
+    /// <returns>The flag string, or null if connection failed</returns>
+    public static async Task<string?> FetchFlag(string entry, WebApplicationFactory<Program>? factory = null)
     {
-        Console.WriteLine($@"🔍 Fetching flag from container entry: {entry}");
+        Console.WriteLine($@"Fetching flag from container entry: {entry}");
 
-        // Parse the Entry field to get IP and port
-        // Entry format is either "proxy-id" or "IP:Port"
-        // For test environments, use localhost since Docker containers are accessible locally
+        // If entry looks like a GUID, use WebSocket proxy; otherwise use direct TCP
+        if (Guid.TryParse(entry, out _))
+        {
+            if (factory is null)
+                throw new InvalidOperationException(
+                    "WebApplicationFactory is required for PlatformProxy (GUID) entry");
+            return await FetchFlagViaProxy(entry, factory);
+        }
+
+        return await FetchFlagViaTcp(entry);
+    }
+
+    /// <summary>
+    /// Fetch flag via direct TCP connection (cloud/k3s mode with exposed ports)
+    /// </summary>
+    static async Task<string?> FetchFlagViaTcp(string entry)
+    {
         var parts = entry.Split(':');
 
         if (parts.Length != 2 || !int.TryParse(parts[1], out var port))
             return null;
 
-        // Use localhost for test environment instead of the container IP
         var host = parts[0];
-
-        // Try to connect to the container and retrieve the flag
         string? flag = null;
+
         for (var attempt = 0; attempt < 10; attempt++)
         {
             try
@@ -161,7 +179,6 @@ public static class ContainerHelper
                 using var client = new TcpClient();
                 await client.ConnectAsync(host, port);
                 await using var stream = client.GetStream();
-                // Read the flag from the echo container
                 var buffer = new byte[256];
                 var bytesRead = await stream.ReadAsync(buffer);
                 flag = System.Text.Encoding.UTF8.GetString(buffer, 0, bytesRead).Trim();
@@ -169,14 +186,53 @@ public static class ContainerHelper
             }
             catch (SocketException) when (attempt < 9)
             {
-                // Container might not be ready yet, retry after delay
                 await Task.Delay(500);
             }
         }
 
-        // Output the retrieved flag for verification
-        Console.WriteLine($@"✅ Successfully retrieved flag from {entry}: {flag}");
+        Console.WriteLine($@"Retrieved flag via TCP from {entry}: {flag}");
+        return flag;
+    }
 
+    /// <summary>
+    /// Fetch flag via WebSocket proxy (local Docker mode with PlatformProxy).
+    /// Connects to the test server's /api/Proxy/{guid} WebSocket endpoint.
+    /// </summary>
+    static async Task<string?> FetchFlagViaProxy(string containerId, WebApplicationFactory<Program> factory)
+    {
+        string? flag = null;
+
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            try
+            {
+                // CreateWebSocketClient uses the TestServer's internal transport,
+                // no real HTTP listener needed
+                var wsClient = factory.Server.CreateWebSocketClient();
+                var wsUri = new Uri(factory.Server.BaseAddress, $"api/Proxy/{containerId}");
+
+                // Replace http(s) scheme with ws(s)
+                var builder = new UriBuilder(wsUri) { Scheme = wsUri.Scheme == "https" ? "wss" : "ws" };
+
+                using var ws = await wsClient.ConnectAsync(builder.Uri, CancellationToken.None);
+
+                // The echo container sends the flag immediately on connection
+                var buffer = new byte[256];
+                var result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+
+                if (result.Count > 0)
+                    flag = System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count).Trim();
+
+                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                break;
+            }
+            catch (Exception) when (attempt < 9)
+            {
+                await Task.Delay(500);
+            }
+        }
+
+        Console.WriteLine($@"Retrieved flag via WebSocket proxy from {containerId}: {flag}");
         return flag;
     }
 

--- a/src/GZCTF.Integration.Test/Base/GZCTFApplicationFactory.cs
+++ b/src/GZCTF.Integration.Test/Base/GZCTFApplicationFactory.cs
@@ -143,6 +143,11 @@ public class GZCTFApplicationFactory : WebApplicationFactory<Program>, IAsyncLif
                     $@"[ConfigureWebHost] Setting ContainerProvider to Docker (K3s mode: {_useK3sMode}, path: {_kubeConfigPath ?? "null"})");
                 configDict["ContainerProvider:Type"] = "Docker";
                 configDict["ContainerProvider:PublicEntry"] = "localhost";
+
+                // Local Docker mode: use platform proxy so traffic flows through
+                // the WebSocket proxy, enabling traffic capture tests
+                configDict["ContainerProvider:PortMappingType"] = "PlatformProxy";
+                configDict["ContainerProvider:EnableTrafficCapture"] = "true";
             }
 
             config.AddInMemoryCollection(configDict);

--- a/src/GZCTF.Integration.Test/Tests/Api/AdvancedGameMechanicsTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/AdvancedGameMechanicsTests.cs
@@ -727,7 +727,7 @@ public class AdvancedGameMechanicsTests(GZCTFApplicationFactory factory, ITestOu
         Assert.Equal(game.Id.ToString(), envVars["GZCTF_GAME_ID"]);
 
         // 5. Fetch the flag
-        var flag = await ContainerHelper.FetchFlag(entry);
+        var flag = await ContainerHelper.FetchFlag(entry, factory);
         Assert.NotNull(flag);
         Assert.StartsWith("flag{", flag);
         Assert.Equal(flag, envVars["GZCTF_FLAG"]);

--- a/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/EditControllerTests.cs
@@ -535,7 +535,7 @@ public class EditControllerTests(GZCTFApplicationFactory factory, ITestOutputHel
 
             output.WriteLine($"✅ Container entry: {entry}");
 
-            var flag = await ContainerHelper.FetchFlag(entry);
+            var flag = await ContainerHelper.FetchFlag(entry, factory);
 
             // Assert: Should have retrieved a flag
             Assert.NotNull(flag);

--- a/src/GZCTF.Integration.Test/Tests/Api/TrafficCaptureTests.cs
+++ b/src/GZCTF.Integration.Test/Tests/Api/TrafficCaptureTests.cs
@@ -1,0 +1,228 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using GZCTF.Integration.Test.Base;
+using GZCTF.Models;
+using GZCTF.Models.Data;
+using GZCTF.Models.Request.Account;
+using GZCTF.Repositories.Interface;
+using GZCTF.Storage.Interface;
+using GZCTF.Utils;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GZCTF.Integration.Test.Tests.Api;
+
+/// <summary>
+/// Integration tests for traffic capture functionality.
+/// Verifies that when PlatformProxy + EnableTrafficCapture are enabled (local Docker mode),
+/// connecting through the WebSocket proxy produces pcap files in blob storage.
+/// </summary>
+[Collection(nameof(IntegrationTestCollection))]
+public class TrafficCaptureTests(GZCTFApplicationFactory factory, ITestOutputHelper output)
+{
+    /// <summary>
+    /// End-to-end test: create a container challenge with traffic capture enabled,
+    /// connect through the proxy, fetch the flag, then verify pcap files were persisted.
+    /// </summary>
+    [Fact]
+    public async Task TrafficCapture_ShouldProducePcapFile_WhenProxyIsUsed()
+    {
+        // Arrange: admin creates a game + dynamic container challenge with traffic capture
+        var adminPassword = "Admin@Pass123";
+        var adminUser = await TestDataSeeder.CreateUserAsync(factory.Services,
+            TestDataSeeder.RandomName(), adminPassword, role: Role.Admin);
+
+        var game = await TestDataSeeder.CreateGameAsync(factory.Services, "Traffic Capture Test");
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var gameEntity = await context.Games.FirstOrDefaultAsync(g => g.Id == game.Id);
+        Assert.NotNull(gameEntity);
+
+        var challengeRepo = scope.ServiceProvider.GetRequiredService<IGameChallengeRepository>();
+        var challenge = await challengeRepo.CreateChallenge(gameEntity,
+            new GameChallenge
+            {
+                Title = "Echo Capture",
+                Type = ChallengeType.DynamicContainer,
+                GameId = game.Id,
+                IsEnabled = true,
+                ContainerImage = "ghcr.io/gzctf/challenge-base/echo:latest",
+                ExposePort = 70,
+                MemoryLimit = 64,
+                CPUCount = 1,
+                StorageLimit = 256,
+                EnableTrafficCapture = true
+            }, CancellationToken.None);
+
+        // Create a regular user + team, join the game
+        var userPassword = "User@Pass123";
+        var userName = TestDataSeeder.RandomName();
+        var user = await TestDataSeeder.CreateUserAsync(factory.Services, userName, userPassword);
+        var team = await TestDataSeeder.CreateTeamAsync(factory.Services, user.Id, $"Capture Team {userName}");
+        var participation = await TestDataSeeder.JoinGameAsync(factory.Services, game.Id, team.Id, user.Id);
+
+        using var userClient = factory.CreateClient();
+        await userClient.PostAsJsonAsync("/api/Account/LogIn",
+            new LoginModel { UserName = user.UserName, Password = userPassword });
+
+        // Act: create the container
+        var createResponse = await userClient.PostAsync($"/api/Game/{game.Id}/Container/{challenge.Id}", null);
+        createResponse.EnsureSuccessStatusCode();
+
+        // Wait for the container to be ready
+        await ContainerHelper.WaitUserContainerAsync(factory.Services, challenge.Id, participation.Id, output);
+
+        // Get the container entry (should be a GUID in PlatformProxy mode)
+        string entry;
+        {
+            var detailResponse = await userClient.GetAsync($"/api/Game/{game.Id}/Challenges/{challenge.Id}");
+            detailResponse.EnsureSuccessStatusCode();
+            var detail = await detailResponse.Content.ReadFromJsonAsync<JsonElement>();
+            var ctx = detail.GetProperty("context");
+            entry = ctx.GetProperty("instanceEntry").GetString()!;
+        }
+
+        Assert.NotEmpty(entry);
+        output.WriteLine($"Container entry: {entry}");
+
+        // The entry should be a GUID (PlatformProxy mode)
+        Assert.True(Guid.TryParse(entry, out var containerId), "Entry should be a GUID in PlatformProxy mode");
+
+        // Fetch the flag through the WebSocket proxy — this generates traffic
+        var flag = await ContainerHelper.FetchFlag(entry, factory);
+        Assert.NotNull(flag);
+        Assert.StartsWith("flag{", flag);
+        output.WriteLine($"Retrieved flag via proxy: {flag}");
+
+        // Destroy the container — this triggers TrafficRecorderRegistry.RemoveAsync
+        // which flushes the pcap file to storage
+        var destroyResponse = await userClient.DeleteAsync($"/api/Game/{game.Id}/Container/{challenge.Id}");
+        Assert.NotEqual(HttpStatusCode.NotFound, destroyResponse.StatusCode);
+
+        // Allow a moment for async flush to complete
+        await Task.Delay(1000);
+
+        // Assert: verify pcap files were created in blob storage
+        var storage = factory.Services.GetRequiredService<IBlobStorage>();
+        var trafficDir = StoragePath.Combine("capture",
+            challenge.Id.ToString(),
+            participation.Id.ToString());
+
+        var files = await storage.ListAsync(trafficDir);
+        Assert.NotEmpty(files);
+
+        var pcapFiles = files.Where(f => f.Name.EndsWith(".pcap")).ToList();
+        Assert.NotEmpty(pcapFiles);
+
+        foreach (var pcap in pcapFiles)
+        {
+            output.WriteLine($"Found pcap: {pcap.Name} ({pcap.Size} bytes)");
+            Assert.True(pcap.Size > 0, $"pcap file {pcap.Name} should not be empty");
+
+            // File name should contain the container short ID
+            var shortId = containerId.ToString("N")[..12];
+            Assert.Contains(shortId, pcap.Name);
+        }
+
+        output.WriteLine($"Total pcap files: {pcapFiles.Count}");
+    }
+
+    /// <summary>
+    /// Verify that multiple connections to the same container produce a single (or few) pcap file(s)
+    /// rather than one per connection, which was the motivation for the shared recorder design.
+    /// </summary>
+    [Fact]
+    public async Task TrafficCapture_ShouldMergeConnections_IntoSharedPcapFile()
+    {
+        var adminPassword = "Admin@Pass123";
+        var adminUser = await TestDataSeeder.CreateUserAsync(factory.Services,
+            TestDataSeeder.RandomName(), adminPassword, role: Role.Admin);
+
+        var game = await TestDataSeeder.CreateGameAsync(factory.Services, "Merge Capture Test");
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var gameEntity = await context.Games.FirstOrDefaultAsync(g => g.Id == game.Id);
+        Assert.NotNull(gameEntity);
+
+        var challengeRepo = scope.ServiceProvider.GetRequiredService<IGameChallengeRepository>();
+        var challenge = await challengeRepo.CreateChallenge(gameEntity,
+            new GameChallenge
+            {
+                Title = "Merge Capture Challenge",
+                Type = ChallengeType.DynamicContainer,
+                GameId = game.Id,
+                IsEnabled = true,
+                ContainerImage = "ghcr.io/gzctf/challenge-base/echo:latest",
+                ExposePort = 70,
+                MemoryLimit = 64,
+                CPUCount = 1,
+                StorageLimit = 256,
+                EnableTrafficCapture = true
+            }, CancellationToken.None);
+
+        var userPassword = "User@Pass123";
+        var userName = TestDataSeeder.RandomName();
+        var user = await TestDataSeeder.CreateUserAsync(factory.Services, userName, userPassword);
+        var team = await TestDataSeeder.CreateTeamAsync(factory.Services, user.Id, $"Merge Team {userName}");
+        var participation = await TestDataSeeder.JoinGameAsync(factory.Services, game.Id, team.Id, user.Id);
+
+        using var userClient = factory.CreateClient();
+        await userClient.PostAsJsonAsync("/api/Account/LogIn",
+            new LoginModel { UserName = user.UserName, Password = userPassword });
+
+        var createResponse = await userClient.PostAsync($"/api/Game/{game.Id}/Container/{challenge.Id}", null);
+        createResponse.EnsureSuccessStatusCode();
+
+        await ContainerHelper.WaitUserContainerAsync(factory.Services, challenge.Id, participation.Id, output);
+
+        string entry;
+        {
+            var detailResponse = await userClient.GetAsync($"/api/Game/{game.Id}/Challenges/{challenge.Id}");
+            detailResponse.EnsureSuccessStatusCode();
+            var detail = await detailResponse.Content.ReadFromJsonAsync<JsonElement>();
+            var ctx = detail.GetProperty("context");
+            entry = ctx.GetProperty("instanceEntry").GetString()!;
+        }
+
+        Assert.True(Guid.TryParse(entry, out var containerId));
+
+        // Connect multiple times in quick succession — all should share the same pcap file
+        const int connectionCount = 5;
+        for (var i = 0; i < connectionCount; i++)
+        {
+            var result = await ContainerHelper.FetchFlag(entry, factory);
+            Assert.NotNull(result);
+            Assert.StartsWith("flag{", result);
+        }
+
+        output.WriteLine($"Completed {connectionCount} connections through proxy");
+
+        // Destroy container to flush
+        await userClient.DeleteAsync($"/api/Game/{game.Id}/Container/{challenge.Id}");
+        await Task.Delay(1000);
+
+        // Verify: should have significantly fewer pcap files than connection count
+        var storage = factory.Services.GetRequiredService<IBlobStorage>();
+        var trafficDir = StoragePath.Combine("capture",
+            challenge.Id.ToString(),
+            participation.Id.ToString());
+
+        var files = await storage.ListAsync(trafficDir);
+        var pcapFiles = files.Where(f => f.Name.EndsWith(".pcap")).ToList();
+
+        Assert.NotEmpty(pcapFiles);
+
+        // The old implementation would produce 5 files (one per connection).
+        // The new shared recorder should produce far fewer — typically 1 since
+        // all connections happen within the idle timeout window.
+        output.WriteLine($"Pcap files for {connectionCount} connections: {pcapFiles.Count}");
+        Assert.True(pcapFiles.Count < connectionCount,
+            $"Expected fewer pcap files ({pcapFiles.Count}) than connections ({connectionCount}) " +
+            "due to shared recorder merging");
+    }
+}

--- a/src/GZCTF/Controllers/ProxyController.cs
+++ b/src/GZCTF/Controllers/ProxyController.cs
@@ -8,7 +8,7 @@ using System.Text.Json;
 using GZCTF.Models.Internal;
 using GZCTF.Repositories.Interface;
 using GZCTF.Services.Cache;
-using GZCTF.Storage.Interface;
+using GZCTF.Services.Capture;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Localization;
@@ -25,7 +25,7 @@ namespace GZCTF.Controllers;
 public class ProxyController(
     ILogger<ProxyController> logger,
     IDistributedCache cache,
-    IBlobStorage storage,
+    TrafficRecorderRegistry recorderRegistry,
     IOptions<ContainerProvider> provider,
     IContainerRepository containerRepository,
     IStringLocalizer<Program> localizer) : ControllerBase
@@ -100,18 +100,17 @@ public class ProxyController(
 
         var enable = _enableTrafficCapture && container.EnableTrafficCapture;
 
-        var metadata = enable ? container.GenerateMetadata(JsonOptions) : null;
-
         IPEndPoint client = new(clientIp, clientPort);
         IPEndPoint target = new(ipAddress, container.Port);
 
-        return await DoContainerProxy(id, client, target, metadata,
+        var recorder = enable ? recorderRegistry.GetOrCreate(container, JsonOptions) : null;
+
+        return await DoContainerProxy(id, client, target, recorder,
             new()
             {
                 Source = client,
                 Dest = target,
-                EnableCapture = enable,
-                BlobPath = container.TrafficPath(HttpContext.Connection.Id)
+                EnableCapture = enable
             }, token);
     }
 
@@ -163,11 +162,12 @@ public class ProxyController(
     }
 
     private async Task<IActionResult> DoContainerProxy(Guid id, IPEndPoint client, IPEndPoint target,
-        byte[]? metadata, RecordableNetworkStreamOptions options, CancellationToken token = default)
+        TrafficRecorder? recorder, RecordableNetworkStreamOptions options, CancellationToken token = default)
     {
         using var socket = new Socket(target.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
         RecordableNetworkStream? stream = null;
+        recorder?.RegisterConnection();
 
         try
         {
@@ -178,7 +178,7 @@ public class ProxyController(
                 if (!socket.Connected)
                     throw new SocketException((int)SocketError.NotConnected);
 
-                stream = new RecordableNetworkStream(socket, metadata, storage, options);
+                stream = new RecordableNetworkStream(socket, options, recorder);
             }
             catch (SocketException e)
             {
@@ -210,6 +210,7 @@ public class ProxyController(
             if (stream is not null)
                 await stream.DisposeAsync();
 
+            recorder?.UnregisterConnection();
             await DecreaseConnectionCount(CacheKey.ConnectionCount(id));
         }
 

--- a/src/GZCTF/Extensions/Startup/ServicesExtension.cs
+++ b/src/GZCTF/Extensions/Startup/ServicesExtension.cs
@@ -5,6 +5,7 @@ using GZCTF.Repositories;
 using GZCTF.Repositories.Interface;
 using GZCTF.Services;
 using GZCTF.Services.Cache;
+using GZCTF.Services.Capture;
 using GZCTF.Services.Config;
 using GZCTF.Services.Container;
 using GZCTF.Services.CronJob;
@@ -88,6 +89,7 @@ internal static class ServicesExtension
             builder.Services.AddChannel<Submission>();
             builder.Services.AddChannel<CacheRequest>();
             builder.Services.AddSingleton<CacheHelper>();
+            builder.Services.AddSingleton<TrafficRecorderRegistry>();
             builder.Services.AddSingleton<IMailSender, MailSender>();
 
             builder.Services.AddHostedService<CacheMaker>();

--- a/src/GZCTF/Models/Data/Container.cs
+++ b/src/GZCTF/Models/Data/Container.cs
@@ -127,6 +127,20 @@ public class Container
     }
 
     /// <summary>
+    /// Container instance traffic capture directory path.
+    /// Used by TrafficRecorder together with <see cref="ShortId"/> to generate pcap filenames.
+    /// </summary>
+    public string TrafficDir()
+    {
+        if (GameInstance is null)
+            return string.Empty;
+
+        return StoragePath.Combine(PathHelper.Capture,
+            GameInstance.ChallengeId.ToString(),
+            GameInstance.ParticipationId.ToString());
+    }
+
+    /// <summary>
     /// Generate metadata for the container
     /// </summary>
     /// <returns></returns>

--- a/src/GZCTF/Repositories/ContainerRepository.cs
+++ b/src/GZCTF/Repositories/ContainerRepository.cs
@@ -1,6 +1,7 @@
 ﻿using GZCTF.Models.Request.Admin;
 using GZCTF.Repositories.Interface;
 using GZCTF.Services.Cache;
+using GZCTF.Services.Capture;
 using GZCTF.Services.Container.Manager;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
@@ -10,6 +11,7 @@ namespace GZCTF.Repositories;
 public class ContainerRepository(
     IDistributedCache cache,
     IContainerManager service,
+    TrafficRecorderRegistry recorderRegistry,
     ILogger<ContainerRepository> logger,
     AppDbContext context) : RepositoryBase(context), IContainerRepository
 {
@@ -55,6 +57,9 @@ public class ContainerRepository(
                 return false;
 
             await cache.RemoveAsync(CacheKey.ConnectionCount(container.Id), token);
+
+            // Flush and remove any active traffic recorder for this container
+            await recorderRegistry.RemoveAsync(container.Id);
 
             Context.Containers.Remove(container);
             await SaveAsync(token);

--- a/src/GZCTF/Resources/Program.de-DE.resx
+++ b/src/GZCTF/Resources/Program.de-DE.resx
@@ -1108,4 +1108,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>Die Frist für diese Herausforderung ist abgelaufen</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Traffic-Aufzeichnung [{0}] gespeichert: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Traffic-Aufzeichnung [{0}] Speichern fehlgeschlagen: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Traffic-Aufzeichnung [{0}] Schreibfehler</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Traffic-Aufzeichnung [{0}] Freigabe-Zeitüberschreitung</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Traffic-Aufzeichnung Shutdown-Zeitüberschreitung, {0} Rekorder ausstehend</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.es-ES.resx
+++ b/src/GZCTF/Resources/Program.es-ES.resx
@@ -1104,4 +1104,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>La fecha límite de este desafío ha pasado</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Captura de tráfico [{0}] guardada: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Captura de tráfico [{0}] error al guardar: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Captura de tráfico [{0}] error de escritura</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Captura de tráfico [{0}] tiempo de espera de liberación agotado</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Cierre de captura de tráfico expirado, {0} grabador(es) pendiente(s)</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.fr-FR.resx
+++ b/src/GZCTF/Resources/Program.fr-FR.resx
@@ -1101,4 +1101,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>La date limite pour ce challenge est dépassée</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Capture de trafic [{0}] enregistrée : {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Capture de trafic [{0}] échec d'enregistrement : {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Capture de trafic [{0}] erreur d'écriture</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Capture de trafic [{0}] délai de libération dépassé</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Arrêt de la capture de trafic expiré, {0} enregistreur(s) en attente</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.id-ID.resx
+++ b/src/GZCTF/Resources/Program.id-ID.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>Batas waktu untuk tantangan ini telah berakhir</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Penangkapan lalu lintas [{0}] tersimpan: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Penangkapan lalu lintas [{0}] gagal menyimpan: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Penangkapan lalu lintas [{0}] kesalahan penulis</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Penangkapan lalu lintas [{0}] waktu pelepasan habis</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Waktu shutdown penangkapan lalu lintas habis, {0} perekam tertunda</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.ja-JP.resx
+++ b/src/GZCTF/Resources/Program.ja-JP.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>このチャレンジの締め切りが過ぎています</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>トラフィックキャプチャ [{0}] 保存完了: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>トラフィックキャプチャ [{0}] 保存失敗: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>トラフィックキャプチャ [{0}] ライターエラー</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>トラフィックキャプチャ [{0}] 破棄タイムアウト</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>トラフィックキャプチャのシャットダウンがタイムアウト、{0} 件のレコーダーが保留中</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.ko-KR.resx
+++ b/src/GZCTF/Resources/Program.ko-KR.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>이 도전 과제의 마감 시간이 지났습니다</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>트래픽 캡처 [{0}] 저장 완료: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>트래픽 캡처 [{0}] 저장 실패: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>트래픽 캡처 [{0}] 기록기 오류</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>트래픽 캡처 [{0}] 해제 시간 초과</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>트래픽 캡처 종료 시간 초과, {0}개 레코더 대기 중</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.resx
+++ b/src/GZCTF/Resources/Program.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>The deadline for this challenge has passed</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Traffic capture [{0}] saved: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Traffic capture [{0}] save failed: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Traffic capture [{0}] writer error</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Traffic capture [{0}] dispose timed out</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Traffic capture shutdown timed out, {0} recorder(s) pending</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.ru-RU.resx
+++ b/src/GZCTF/Resources/Program.ru-RU.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>Срок сдачи этого задания истёк</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Захват трафика [{0}] сохранён: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Захват трафика [{0}] не удалось сохранить: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Захват трафика [{0}] ошибка записи</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Захват трафика [{0}] тайм-аут освобождения</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Тайм-аут завершения захвата трафика, {0} рекордер(ов) в ожидании</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.vi-VN.resx
+++ b/src/GZCTF/Resources/Program.vi-VN.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>Thời hạn cho thử thách này đã hết</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>Bắt lưu lượng [{0}] đã lưu: {1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>Bắt lưu lượng [{0}] lưu thất bại: {1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>Bắt lưu lượng [{0}] lỗi ghi</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>Bắt lưu lượng [{0}] hết thời gian giải phóng</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>Tắt bắt lưu lượng hết thời gian, {0} bộ ghi đang chờ</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.zh-CN.resx
+++ b/src/GZCTF/Resources/Program.zh-CN.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>该题目的截止时间已过</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>流量捕获 [{0}] 已保存：{1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>流量捕获 [{0}] 保存失败：{1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>流量捕获 [{0}] 写入器错误</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>流量捕获 [{0}] 释放超时</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>流量捕获关闭超时，{0} 个记录器待处理</value>
+  </data>
 </root>

--- a/src/GZCTF/Resources/Program.zh-TW.resx
+++ b/src/GZCTF/Resources/Program.zh-TW.resx
@@ -1088,4 +1088,19 @@
   <data name="Challenge_DeadlinePassed" xml:space="preserve">
     <value>此題目的截止時間已過</value>
   </data>
+  <data name="TrafficRecorder_Persisted" xml:space="preserve">
+    <value>流量擷取 [{0}] 已儲存：{1}</value>
+  </data>
+  <data name="TrafficRecorder_PersistFailed" xml:space="preserve">
+    <value>流量擷取 [{0}] 儲存失敗：{1}</value>
+  </data>
+  <data name="TrafficRecorder_WriterLoopError" xml:space="preserve">
+    <value>流量擷取 [{0}] 寫入器錯誤</value>
+  </data>
+  <data name="TrafficRecorder_DisposeTimeout" xml:space="preserve">
+    <value>流量擷取 [{0}] 釋放逾時</value>
+  </data>
+  <data name="TrafficRecorder_ShutdownTimeout" xml:space="preserve">
+    <value>流量擷取關閉逾時，{0} 個記錄器待處理</value>
+  </data>
 </root>

--- a/src/GZCTF/Services/Capture/CapturePacket.cs
+++ b/src/GZCTF/Services/Capture/CapturePacket.cs
@@ -1,0 +1,17 @@
+using System.Net;
+
+namespace GZCTF.Services.Capture;
+
+/// <summary>
+/// Represents a single captured traffic packet to be written to a pcap file.
+/// </summary>
+/// <param name="Source">The source address of the packet</param>
+/// <param name="Dest">The destination address of the packet</param>
+/// <param name="Data">The raw payload data (must be a copy, not a rented buffer slice)</param>
+/// <param name="Timestamp">The time the packet was captured</param>
+public readonly record struct CapturePacket(
+    IPEndPoint Source,
+    IPEndPoint Dest,
+    byte[] Data,
+    DateTimeOffset Timestamp
+);

--- a/src/GZCTF/Services/Capture/TrafficRecorder.cs
+++ b/src/GZCTF/Services/Capture/TrafficRecorder.cs
@@ -1,0 +1,329 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading.Channels;
+using GZCTF.Storage.Interface;
+using PacketDotNet;
+using PacketDotNet.Utils;
+using SharpPcap;
+using SharpPcap.LibPcap;
+
+namespace GZCTF.Services.Capture;
+
+/// <summary>
+/// Represents a command sent through the capture channel.
+/// Either a data packet to write, or a flush signal.
+/// </summary>
+readonly struct CaptureCommand
+{
+    public CapturePacket? Packet { get; init; }
+    public bool IsFlush { get; init; }
+
+    public static CaptureCommand Data(CapturePacket packet) => new() { Packet = packet };
+    public static CaptureCommand Flush() => new() { IsFlush = true };
+}
+
+/// <summary>
+/// A per-container traffic recorder that multiplexes concurrent connections into shared pcap files.
+/// Uses a Channel-based pipeline with a single writer task to ensure thread-safe pcap writes.
+/// Implements idle-timeout based file rotation: when all connections disconnect and no new
+/// connection arrives within the idle timeout, the current pcap file is flushed and persisted.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "Network stream recording requires platform proxy support")]
+public sealed class TrafficRecorder : IAsyncDisposable
+{
+    /// <summary>
+    /// Maximum time to wait for the writer task to finish during disposal.
+    /// If exceeded, the writer task is abandoned and resources are cleaned up best-effort.
+    /// </summary>
+    static readonly TimeSpan DisposeTimeout = TimeSpan.FromSeconds(10);
+
+    static readonly PhysicalAddress DummyPhysicalAddress = PhysicalAddress.Parse("00-11-00-11-00-11");
+    
+    readonly string _shortId;
+    readonly string _directory;
+    readonly string _filePrefix;
+    readonly byte[]? _metadata;
+    readonly IBlobStorage _storage;
+    readonly ILogger<TrafficRecorderRegistry> _logger;
+    readonly TimeSpan _idleTimeout;
+    readonly long _maxFileSize;
+
+    readonly Channel<CaptureCommand> _channel;
+    readonly CancellationTokenSource _cts;
+    readonly Task _writerTask;
+
+    int _activeConnections;
+    int _fileSequence;
+    readonly Timer _idleTimer;
+
+    // Only accessed by the writer task (single reader)
+    CaptureFileWriterDevice? _device;
+    string _tempFile = string.Empty;
+    bool _hasRecord;
+    long _currentFileSize;
+    DateTimeOffset _windowStart;
+
+    bool _disposed;
+    
+    /// <summary>
+    /// Creates a new TrafficRecorder for a container.
+    /// </summary>
+    public TrafficRecorder(
+        Guid containerId,
+        string directory,
+        string filePrefix,
+        byte[]? metadata,
+        IBlobStorage storage,
+        ILogger<TrafficRecorderRegistry> logger,
+        TimeSpan idleTimeout,
+        CancellationToken registryToken,
+        long maxFileSize = 50 * 1024 * 1024)
+    {
+        _shortId = containerId.ToString("N")[..12];
+        _directory = directory;
+        _filePrefix = filePrefix;
+        _metadata = metadata;
+        _storage = storage;
+        _logger = logger;
+        _idleTimeout = idleTimeout;
+        _maxFileSize = maxFileSize;
+
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(registryToken);
+        _idleTimer = new Timer(OnIdleTimeout, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+        _channel = Channel.CreateUnbounded<CaptureCommand>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        _writerTask = Task.Run(WriterLoopAsync);
+    }
+
+    /// <summary>
+    /// Write a captured packet. Called from any connection's read/write path.
+    /// </summary>
+    public void WritePacket(CapturePacket packet) => _channel.Writer.TryWrite(CaptureCommand.Data(packet));
+
+    /// <summary>
+    /// Register a new connection to this recorder.
+    /// Cancels any pending idle timer and increments the active connection count.
+    /// </summary>
+    public void RegisterConnection()
+    {
+        Interlocked.Increment(ref _activeConnections);
+        CancelIdleTimer();
+    }
+
+    /// <summary>
+    /// Unregister a connection from this recorder.
+    /// When the last connection disconnects, starts the idle timer.
+    /// </summary>
+    public void UnregisterConnection()
+    {
+        var remaining = Interlocked.Decrement(ref _activeConnections);
+        if (remaining <= 0)
+            StartIdleTimer();
+    }
+
+    /// <summary>
+    /// The single-threaded writer loop that consumes commands from the channel.
+    /// </summary>
+    async Task WriterLoopAsync()
+    {
+        var token = _cts.Token;
+
+        try
+        {
+            await foreach (var command in _channel.Reader.ReadAllAsync(token))
+            {
+                if (command.IsFlush)
+                {
+                    await FlushAndPersistAsync(token);
+                    continue;
+                }
+
+                if (command.Packet is not { } packet)
+                    continue;
+
+                EnsureDeviceOpen();
+                WritePcapPacket(packet);
+
+                if (_currentFileSize > _maxFileSize)
+                    await FlushAndPersistAsync(token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during disposal or registry shutdown
+        }
+        catch (Exception ex)
+        {
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.TrafficRecorder_WriterLoopError), _shortId],
+                TaskStatus.Failed, LogLevel.Error);
+            _logger.LogErrorMessage(ex);
+        }
+        finally
+        {
+            // Best-effort final flush, bounded by DisposeTimeout in DisposeAsync
+            await FlushAndPersistAsync(CancellationToken.None);
+        }
+    }
+
+    void EnsureDeviceOpen()
+    {
+        if (_device is not null)
+            return;
+
+        _windowStart = DateTimeOffset.UtcNow;
+        _tempFile = Path.GetTempFileName();
+        _device = new CaptureFileWriterDevice(_tempFile, FileMode.Open);
+        _device.Open();
+        _hasRecord = false;
+        _currentFileSize = 0;
+
+        if (_metadata is null)
+            return;
+
+        var host = new IPEndPoint(IPAddress.Any.MapToIPv6(), 65535);
+        var dest = new IPEndPoint(IPAddress.Any.MapToIPv6(), 0);
+        WritePcapPacketCore(host, dest, _metadata);
+    }
+
+    void WritePcapPacket(CapturePacket packet) =>
+        WritePcapPacketCore(packet.Source, packet.Dest, packet.Data, packet.Timestamp);
+
+    void WritePcapPacketCore(IPEndPoint source, IPEndPoint dest, byte[] data,
+        DateTimeOffset? timestamp = null)
+    {
+        var udp = new UdpPacket((ushort)source.Port, (ushort)dest.Port)
+        {
+            PayloadDataSegment = new ByteArraySegment(data)
+        };
+
+        var packet = new EthernetPacket(DummyPhysicalAddress, DummyPhysicalAddress, EthernetType.IPv6)
+        {
+            PayloadPacket = new IPv6Packet(source.Address, dest.Address) { PayloadPacket = udp }
+        };
+
+        udp.UpdateUdpChecksum();
+
+        var rawBytes = packet.Bytes;
+        var time = new PosixTimeval(timestamp?.UtcDateTime ?? DateTime.UtcNow);
+        _device?.Write(new RawCapture(LinkLayers.Ethernet, time, rawBytes));
+        _currentFileSize += rawBytes.Length;
+        _hasRecord = true;
+    }
+
+    /// <summary>
+    /// Flush and persist the current pcap file to blob storage.
+    /// Only called from the writer task, ensuring thread safety.
+    /// </summary>
+    async Task FlushAndPersistAsync(CancellationToken token)
+    {
+        if (_device is null)
+            return;
+
+        var device = _device;
+        var tempFile = _tempFile;
+        var hasRecord = _hasRecord;
+        var blobPath = CurrentBlobPath();
+
+        _device = null;
+        _tempFile = string.Empty;
+        _hasRecord = false;
+        _currentFileSize = 0;
+
+        try
+        {
+            device.Close();
+            device.Dispose();
+
+            if (hasRecord)
+            {
+                await _storage.WriteFileAsync(blobPath, tempFile, token);
+                _logger.SystemLog(
+                    StaticLocalizer[nameof(Resources.Program.TrafficRecorder_Persisted), _shortId, blobPath],
+                    TaskStatus.Success, LogLevel.Debug);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Persist canceled — logged at Warning since data may be lost
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.TrafficRecorder_PersistFailed), _shortId, blobPath],
+                TaskStatus.Failed, LogLevel.Warning);
+        }
+        catch (Exception ex)
+        {
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.TrafficRecorder_PersistFailed), _shortId, blobPath],
+                TaskStatus.Failed, LogLevel.Error);
+            _logger.LogErrorMessage(ex);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempFile))
+                    File.Delete(tempFile);
+            }
+            catch
+            {
+                // best effort
+            }
+
+            _fileSequence++;
+        }
+    }
+
+    string CurrentBlobPath()
+    {
+        var timestamp = _windowStart.ToString("yyyyMMdd-HHmmss");
+        var suffix = _fileSequence > 0 ? $"-{_fileSequence}" : "";
+        return StoragePath.Combine(_directory, $"{_filePrefix}-{timestamp}{suffix}.pcap");
+    }
+
+    void StartIdleTimer() => _idleTimer.Change(_idleTimeout, Timeout.InfiniteTimeSpan);
+
+    void CancelIdleTimer() => _idleTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+    void OnIdleTimeout(object? state)
+    {
+        if (Volatile.Read(ref _activeConnections) > 0)
+            return;
+
+        _channel.Writer.TryWrite(CaptureCommand.Flush());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        _channel.Writer.TryComplete();
+        await _idleTimer.DisposeAsync();
+        await _cts.CancelAsync();
+
+        try
+        {
+            await _writerTask.WaitAsync(DisposeTimeout);
+        }
+        catch (TimeoutException)
+        {
+            _logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.TrafficRecorder_DisposeTimeout), _shortId],
+                TaskStatus.Failed, LogLevel.Warning);
+        }
+        catch
+        {
+            // Swallow — we're disposing, nothing useful to do with the error
+        }
+
+        _cts.Dispose();
+    }
+}

--- a/src/GZCTF/Services/Capture/TrafficRecorderRegistry.cs
+++ b/src/GZCTF/Services/Capture/TrafficRecorderRegistry.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using GZCTF.Storage.Interface;
+
+namespace GZCTF.Services.Capture;
+
+/// <summary>
+/// Global singleton registry that manages per-container TrafficRecorder instances.
+/// Ensures that concurrent connections to the same container share a single pcap writer.
+///
+/// Owns a root CancellationTokenSource that propagates to all child recorders.
+/// On disposal (application shutdown), the root token is cancelled, which signals all
+/// writer loops to stop. Each recorder's DisposeAsync then waits with a bounded timeout.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "Network stream recording requires platform proxy support")]
+public sealed class TrafficRecorderRegistry(
+    IBlobStorage storage,
+    ILogger<TrafficRecorderRegistry> logger) : IAsyncDisposable
+{
+    static readonly TimeSpan DefaultIdleTimeout = TimeSpan.FromSeconds(30);
+    static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(15);
+
+    readonly CancellationTokenSource _rootCts = new();
+    readonly ConcurrentDictionary<Guid, TrafficRecorder> _recorders = new();
+    bool _disposed;
+
+    /// <summary>
+    /// Get or create a TrafficRecorder for the specified container.
+    /// If a recorder already exists, it is returned directly; the container is only
+    /// read when a new recorder needs to be created.
+    /// </summary>
+    public TrafficRecorder GetOrCreate(Models.Data.Container container, JsonSerializerOptions jsonOptions) =>
+        _recorders.GetOrAdd(container.Id, _ => new TrafficRecorder(
+            container.Id,
+            container.TrafficDir(),
+            container.ShortId,
+            container.GenerateMetadata(jsonOptions),
+            storage,
+            logger,
+            DefaultIdleTimeout,
+            _rootCts.Token
+        ));
+
+    /// <summary>
+    /// Remove and dispose the TrafficRecorder for the specified container.
+    /// Called when a container is destroyed to ensure all captured traffic is flushed.
+    /// </summary>
+    public async ValueTask RemoveAsync(Guid containerId)
+    {
+        if (!_recorders.TryRemove(containerId, out var recorder))
+            return;
+
+        await recorder.DisposeAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        await _rootCts.CancelAsync();
+
+        var recorders = _recorders.ToArray();
+        _recorders.Clear();
+
+        if (recorders.Length == 0)
+        {
+            _rootCts.Dispose();
+            return;
+        }
+
+        var disposeTasks = recorders.Select(async kv =>
+        {
+            try
+            {
+                await kv.Value.DisposeAsync();
+            }
+            catch
+            {
+                // Individual recorder errors are logged inside DisposeAsync
+            }
+        });
+
+        try
+        {
+            await Task.WhenAll(disposeTasks).WaitAsync(ShutdownTimeout);
+        }
+        catch (TimeoutException)
+        {
+            logger.SystemLog(
+                StaticLocalizer[nameof(Resources.Program.TrafficRecorder_ShutdownTimeout), recorders.Length],
+                TaskStatus.Failed, LogLevel.Warning);
+        }
+
+        _rootCts.Dispose();
+    }
+}

--- a/src/GZCTF/Utils/RecordableNetworkStream.cs
+++ b/src/GZCTF/Utils/RecordableNetworkStream.cs
@@ -1,31 +1,21 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.NetworkInformation;
 using System.Net.Sockets;
-using GZCTF.Storage.Interface;
-using PacketDotNet;
-using PacketDotNet.Utils;
-using SharpPcap;
-using SharpPcap.LibPcap;
+using GZCTF.Services.Capture;
 
 namespace GZCTF.Utils;
 
 public class RecordableNetworkStreamOptions
 {
     /// <summary>
-    /// The source address of the traffic
+    /// The source address of the traffic (client side)
     /// </summary>
     public IPEndPoint Source { get; init; } = new(0, 0);
 
     /// <summary>
-    /// The destination address of the traffic
+    /// The destination address of the traffic (container side)
     /// </summary>
     public IPEndPoint Dest { get; init; } = new(0, 0);
-
-    /// <summary>
-    /// The path to store the captured traffic
-    /// </summary>
-    public string BlobPath { get; init; } = string.Empty;
 
     /// <summary>
     /// Is the capture enabled
@@ -34,50 +24,37 @@ public class RecordableNetworkStreamOptions
 }
 
 /// <summary>
-/// The network stream that can record the traffic
+/// A network stream that records traffic by sending captured packets to a shared TrafficRecorder.
+/// Instead of writing pcap files directly, packets are forwarded through the recorder's channel
+/// so that concurrent connections to the same container share a single pcap output.
 /// </summary>
 [ExcludeFromCodeCoverage(Justification = "Network stream recording requires platform proxy support")]
 public sealed class RecordableNetworkStream : NetworkStream
 {
-    private static readonly PhysicalAddress DummyPhysicalAddress = PhysicalAddress.Parse("00-11-00-11-00-11");
-    private static readonly IPEndPoint Host = new(0, 65535);
+    readonly RecordableNetworkStreamOptions _options;
+    readonly TrafficRecorder? _recorder;
 
-    private readonly CaptureFileWriterDevice? _device;
-    private readonly RecordableNetworkStreamOptions _options;
-    private readonly IBlobStorage? _storage;
-    private readonly string _tempFile = string.Empty;
+    bool _disposed;
 
-    private bool _disposed;
-    private bool _hasRecord;
-
-    public RecordableNetworkStream(Socket socket, byte[]? metadata, IBlobStorage storage,
-        RecordableNetworkStreamOptions options) :
+    public RecordableNetworkStream(Socket socket, RecordableNetworkStreamOptions options,
+        TrafficRecorder? recorder = null) :
         base(socket)
     {
         _options = options;
+        _recorder = options.EnableCapture ? recorder : null;
 
-        options.Source.Address = options.Source.Address.MapToIPv6();
-        options.Dest.Address = options.Dest.Address.MapToIPv6();
-
-        if (!_options.EnableCapture || string.IsNullOrEmpty(_options.BlobPath))
-            return;
-
-        _storage = storage;
-        _tempFile = Path.GetTempFileName();
-
-        _device = new(_tempFile, FileMode.Open);
-
-        _device.Open();
-
-        if (metadata is not null)
-            WriteCapturedData(Host, _options.Source, metadata);
+        if (_recorder is not null)
+        {
+            options.Source.Address = options.Source.Address.MapToIPv6();
+            options.Dest.Address = options.Dest.Address.MapToIPv6();
+        }
     }
 
     public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
     {
         var count = await base.ReadAsync(buffer, cancellationToken);
 
-        if (_options.EnableCapture && count > 0)
+        if (_recorder is not null && count > 0)
             WriteCapturedData(_options.Dest, _options.Source, buffer[..count]);
 
         return count;
@@ -85,54 +62,30 @@ public sealed class RecordableNetworkStream : NetworkStream
 
     public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
     {
-        if (_options.EnableCapture && buffer.Length > 0)
+        if (_recorder is not null && buffer.Length > 0)
             WriteCapturedData(_options.Source, _options.Dest, buffer);
 
         return base.WriteAsync(buffer, cancellationToken);
     }
 
     /// <summary>
-    /// Write the captured data to the file
+    /// Send captured data to the shared TrafficRecorder via its channel.
+    /// The data is copied because the original buffer may be returned to ArrayPool.
     /// </summary>
     /// <param name="source">Source address</param>
     /// <param name="dest">Destination address</param>
     /// <param name="buffer">Data buffer</param>
-    private void WriteCapturedData(IPEndPoint source, IPEndPoint dest, ReadOnlyMemory<byte> buffer)
-    {
-        var udp = new UdpPacket((ushort)source.Port, (ushort)dest.Port)
-        {
-            PayloadDataSegment = new ByteArraySegment(buffer.ToArray())
-        };
-
-        var packet = new EthernetPacket(DummyPhysicalAddress, DummyPhysicalAddress, EthernetType.IPv6)
-        {
-            PayloadPacket = new IPv6Packet(source.Address, dest.Address) { PayloadPacket = udp }
-        };
-
-        udp.UpdateUdpChecksum();
-
-        _device?.Write(new RawCapture(LinkLayers.Ethernet, new(), packet.Bytes));
-
-        _hasRecord = true;
-    }
+    void WriteCapturedData(IPEndPoint source, IPEndPoint dest, ReadOnlyMemory<byte> buffer) =>
+        _recorder?.WritePacket(new CapturePacket(source, dest, buffer.ToArray(), DateTimeOffset.UtcNow));
 
     public override async ValueTask DisposeAsync()
     {
         if (_disposed)
             return;
 
-        _device?.Close();
-        _device?.Dispose();
-
-        // move temp file to storage with specified path
-        if (_options.EnableCapture && !string.IsNullOrEmpty(_options.BlobPath) && _storage is not null)
-        {
-            // only save traffic with records
-            if (_hasRecord)
-                await _storage.WriteFileAsync(_options.BlobPath, _tempFile);
-
-            File.Delete(_tempFile);
-        }
+        // Note: we do NOT dispose/flush the recorder here.
+        // The recorder is shared across connections and managed by TrafficRecorderRegistry.
+        // Connection unregistration is handled by ProxyController.
 
         await base.DisposeAsync();
         GC.SuppressFinalize(this);


### PR DESCRIPTION
Refactor traffic capture from per-connection pcap files to a shared
per-container model using Channel-based pipeline with a single writer
task, reducing small file proliferation under concurrent connections.

- Add TrafficRecorder: per-container pcap writer with idle-timeout (30s)
  flush, file size rotation (50MB), and CancellationToken tree from
  registry for graceful shutdown with bounded timeouts
- Add TrafficRecorderRegistry: singleton managing recorder lifecycle,
  root CTS propagation, parallel dispose on shutdown
- Simplify RecordableNetworkStream to forward packets via Channel
  instead of directly writing pcap (fixes concurrent write hazard)
- Connections distinguished by (srcIP, srcPort, dstIP, dstPort) tuple
- Preserve original capture timestamps in pcap via PosixTimeval
- Flush on container destroy via ContainerRepository integration
- Add localized log messages (11 languages) for persist/error events